### PR TITLE
Add return, if, foreach, switch, assign statements

### DIFF
--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/AssignmentDescription.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/AssignmentDescription.java
@@ -1,0 +1,20 @@
+package com.infosupport.ldoc.analyzerj.descriptions;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AssignmentDescription(
+    @JsonProperty("Left")
+    String left,
+
+    @JsonProperty("Operator")
+    String operator,
+
+    @JsonProperty("Right")
+    String right
+) implements Description {
+
+  @JsonProperty("$type")
+  public String getType() {
+    return "LivingDocumentation.AssignmentDescription, LivingDocumentation.Descriptions";
+  }
+}

--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/ForEachDescription.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/ForEachDescription.java
@@ -1,0 +1,21 @@
+package com.infosupport.ldoc.analyzerj.descriptions;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record ForEachDescription(
+    @JsonProperty("Expression")
+    String expression,
+
+    @JsonProperty("Statements")
+    @JsonInclude(Include.NON_EMPTY)
+    List<Description> statements
+) implements Description {
+
+  @JsonProperty("$type")
+  public String getType() {
+    return "LivingDocumentation.ForEach, LivingDocumentation.Statements";
+  }
+}

--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/IfDescription.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/IfDescription.java
@@ -1,0 +1,18 @@
+package com.infosupport.ldoc.analyzerj.descriptions;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record IfDescription(
+    @JsonProperty("Sections")
+    @JsonInclude(Include.NON_EMPTY)
+    List<IfElseSection> sections
+) implements Description {
+
+  @JsonProperty("$type")
+  public String getType() {
+    return "LivingDocumentation.If, LivingDocumentation.Statements";
+  }
+}

--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/IfElseSection.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/IfElseSection.java
@@ -1,0 +1,18 @@
+package com.infosupport.ldoc.analyzerj.descriptions;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record IfElseSection(
+    @JsonProperty("Condition")
+    @JsonInclude(Include.NON_NULL)
+    String condition,
+
+    @JsonProperty("Statements")
+    @JsonInclude(Include.NON_EMPTY)
+    List<Description> statements
+) implements Description {
+
+}

--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/ReturnDescription.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/ReturnDescription.java
@@ -1,0 +1,21 @@
+package com.infosupport.ldoc.analyzerj.descriptions;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record ReturnDescription(
+    @JsonProperty("Expression")
+    @JsonInclude(Include.NON_NULL)
+    String expression
+) implements Description {
+
+  public ReturnDescription() {
+    this(null);
+  }
+
+  @JsonProperty("$type")
+  public String getType() {
+    return "LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions";
+  }
+}

--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/SwitchDescription.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/SwitchDescription.java
@@ -1,0 +1,21 @@
+package com.infosupport.ldoc.analyzerj.descriptions;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record SwitchDescription(
+    @JsonProperty("Expression")
+    String expression,
+
+    @JsonProperty("Sections")
+    @JsonInclude(Include.NON_EMPTY)
+    List<Description> sections
+) implements Description {
+
+  @JsonProperty("$type")
+  public String getType() {
+    return "LivingDocumentation.Switch, LivingDocumentation.Statements";
+  }
+}

--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/SwitchSection.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/SwitchSection.java
@@ -1,0 +1,18 @@
+package com.infosupport.ldoc.analyzerj.descriptions;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record SwitchSection(
+    @JsonProperty("Labels")
+    @JsonInclude(Include.NON_EMPTY)
+    List<String> labels,
+
+    @JsonProperty("Statements")
+    @JsonInclude(Include.NON_EMPTY)
+    List<Description> statements
+) implements Description {
+
+}

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/AssignmentDescriptionJSONTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/AssignmentDescriptionJSONTest.java
@@ -1,0 +1,27 @@
+package com.infosupport.ldoc.analyzerj.descriptions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+class AssignmentDescriptionJSONTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void assignment_description_serializes_as_expected() throws IOException {
+    String expected = """
+          {
+            "$type": "LivingDocumentation.AssignmentDescription, LivingDocumentation.Descriptions",
+            "Left": "ringo",
+            "Operator": "=",
+            "Right": "george"
+          }
+        """;
+    assertEquals(
+        mapper.readTree(expected),
+        mapper.valueToTree(new AssignmentDescription("ringo", "=", "george")));
+  }
+}

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/ForEachDescriptionJSONTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/ForEachDescriptionJSONTest.java
@@ -1,0 +1,33 @@
+package com.infosupport.ldoc.analyzerj.descriptions;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ForEachDescriptionJSONTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void foreach_description_serializes_as_expected() throws IOException {
+    String expected = """
+        {
+          "$type": "LivingDocumentation.ForEach, LivingDocumentation.Statements",
+          "Expression": "String piece : pieces",
+          "Statements": [
+            {
+              "$type": "LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions"
+            }
+          ]
+        }
+        """;
+
+    assertEquals(
+        mapper.readTree(expected),
+        mapper.valueToTree(
+            new ForEachDescription("String piece : pieces", List.of(new ReturnDescription()))));
+  }
+}

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/IfDescriptionJSONTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/IfDescriptionJSONTest.java
@@ -1,0 +1,51 @@
+package com.infosupport.ldoc.analyzerj.descriptions;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class IfDescriptionJSONTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void if_description_serializes_as_expected() throws IOException {
+    String expected = """
+        {
+          "$type": "LivingDocumentation.If, LivingDocumentation.Statements",
+          "Sections": [
+            {
+              "Condition": "true",
+              "Statements": [
+                {
+                  "$type": "LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions",
+                  "Expression": "1"
+                }
+              ]
+            },
+            {
+              "Condition": "false"
+            },
+            {
+              "Statements": [
+                {
+                  "$type": "LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions",
+                  "Expression": "2"
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    assertEquals(
+        mapper.readTree(expected),
+        mapper.valueToTree(new IfDescription(List.of(
+            new IfElseSection("true", List.of(new ReturnDescription("1"))),
+            new IfElseSection("false", List.of()),
+            new IfElseSection(null, List.of(new ReturnDescription("2")))))));
+  }
+}

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/ReturnDescriptionJSONTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/ReturnDescriptionJSONTest.java
@@ -1,0 +1,30 @@
+package com.infosupport.ldoc.analyzerj.descriptions;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+class ReturnDescriptionJSONTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void return_description_serializes_as_expected() throws IOException {
+    String plain = """
+        {
+          "$type": "LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions"
+        }
+        """;
+    String value = """
+        {
+          "$type": "LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions",
+          "Expression": "1"
+        }
+        """;
+
+    assertEquals(mapper.readTree(plain), mapper.valueToTree(new ReturnDescription()));
+    assertEquals(mapper.readTree(value), mapper.valueToTree(new ReturnDescription("1")));
+  }
+}

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/SwitchDescriptionJSONTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/SwitchDescriptionJSONTest.java
@@ -1,0 +1,51 @@
+package com.infosupport.ldoc.analyzerj.descriptions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SwitchDescriptionJSONTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void switch_description_serializes_as_expected() throws IOException {
+    String expected = """
+        {
+          "$type": "LivingDocumentation.Switch, LivingDocumentation.Statements",
+          "Expression": "season",
+          "Sections": [
+            {
+              "Labels": ["Spring"],
+              "Statements": [
+                {
+                  "$type": "LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions"
+                }
+              ]
+            },
+            {
+              "Labels": ["Summer"]
+            },
+            {
+              "Labels": ["default"],
+              "Statements": [
+                {
+                  "$type": "LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions"
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    assertEquals(
+        mapper.readTree(expected),
+        mapper.valueToTree(new SwitchDescription("season", List.of(
+            new SwitchSection(List.of("Spring"), List.of(new ReturnDescription())),
+            new SwitchSection(List.of("Summer"), List.of()),
+            new SwitchSection(List.of("default"), List.of(new ReturnDescription()))))));
+  }
+}


### PR DESCRIPTION
This is based on #9, which should be merged first. It is a bit larger than the other ones.

A few things to note:

* We flatten if-else trees, in an attempt to follow what upstream does.
* Upstream, the `$type` keys are generated automatically, but we do it manually so we can make sure the values exactly match upstream.
* Assignment is an expression in Java, not a statement, but upstream seems to treat it like a statement at top level so we do as well.

Also adds tests.