### PR TITLE
Add invocations (method calls)

### DIFF
--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
@@ -10,8 +10,10 @@ import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.body.RecordDeclaration;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.AssignExpr;
+import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MarkerAnnotationExpr;
 import com.github.javaparser.ast.expr.MemberValuePair;
+import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NormalAnnotationExpr;
 import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.ast.stmt.ForEachStmt;
@@ -25,6 +27,7 @@ import com.github.javaparser.ast.visitor.GenericListVisitorAdapter;
 import com.github.javaparser.resolution.SymbolResolver;
 import com.github.javaparser.resolution.declarations.ResolvedAnnotationDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
+import com.infosupport.ldoc.analyzerj.descriptions.ArgumentDescription;
 import com.infosupport.ldoc.analyzerj.descriptions.AssignmentDescription;
 import com.infosupport.ldoc.analyzerj.descriptions.AttributeArgumentDescription;
 import com.infosupport.ldoc.analyzerj.descriptions.AttributeDescription;
@@ -33,6 +36,7 @@ import com.infosupport.ldoc.analyzerj.descriptions.Description;
 import com.infosupport.ldoc.analyzerj.descriptions.ForEachDescription;
 import com.infosupport.ldoc.analyzerj.descriptions.IfDescription;
 import com.infosupport.ldoc.analyzerj.descriptions.IfElseSection;
+import com.infosupport.ldoc.analyzerj.descriptions.InvocationDescription;
 import com.infosupport.ldoc.analyzerj.descriptions.MemberDescription;
 import com.infosupport.ldoc.analyzerj.descriptions.MethodDescription;
 import com.infosupport.ldoc.analyzerj.descriptions.ParameterDescription;
@@ -216,5 +220,20 @@ public class AnalysisVisitor extends GenericListVisitorAdapter<Description, Anal
   public List<Description> visit(AssignExpr n, Analyzer arg) {
     return List.of(
         new AssignmentDescription(n.getTarget().toString(), "=", n.getValue().toString()));
+  }
+
+  @Override
+  public List<Description> visit(MethodCallExpr n, Analyzer arg) {
+    List<Description> arguments = new ArrayList<>();
+    for (Expression argument : n.getArguments()) {
+      String type = resolver.calculateType(argument).describe();
+      String text = argument.toString();
+      arguments.add(new ArgumentDescription(type, text));
+    }
+
+    return List.of(new InvocationDescription(
+        n.getScope().map(s -> resolver.calculateType(s).describe()).orElse("?"),
+        n.getNameAsString(),
+        arguments));
   }
 }

--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/Analyzer.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/Analyzer.java
@@ -32,7 +32,8 @@ public class Analyzer {
         CompilationUnit compilationUnit = result.getResult().orElseThrow();
         AnalysisVisitor visitor = new AnalysisVisitor(solver);
 
-        descriptions.addAll(compilationUnit.accept(visitor, this));
+        List<Description> visited = compilationUnit.accept(visitor, this);
+        descriptions.addAll(visited);
       }
     }
 

--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/ArgumentDescription.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/ArgumentDescription.java
@@ -1,0 +1,13 @@
+package com.infosupport.ldoc.analyzerj.descriptions;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record ArgumentDescription(
+    @JsonProperty("Type")
+    String type,
+
+    @JsonProperty("Text")
+    String text
+) implements Description {
+
+}

--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/InvocationDescription.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/InvocationDescription.java
@@ -1,0 +1,24 @@
+package com.infosupport.ldoc.analyzerj.descriptions;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record InvocationDescription(
+    @JsonProperty("ContainingType")
+    String containingType,
+
+    @JsonProperty("Name")
+    String name,
+
+    @JsonProperty("Arguments")
+    @JsonInclude(Include.NON_EMPTY)
+    List<Description> arguments
+) implements Description {
+
+  @JsonProperty("$type")
+  public String getType() {
+    return "LivingDocumentation.InvocationDescription, LivingDocumentation.Descriptions";
+  }
+}

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
@@ -7,6 +7,7 @@ import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.resolution.SymbolResolver;
 import com.github.javaparser.symbolsolver.JavaSymbolSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import com.infosupport.ldoc.analyzerj.descriptions.ArgumentDescription;
 import com.infosupport.ldoc.analyzerj.descriptions.AssignmentDescription;
 import com.infosupport.ldoc.analyzerj.descriptions.AttributeArgumentDescription;
 import com.infosupport.ldoc.analyzerj.descriptions.AttributeDescription;
@@ -15,6 +16,7 @@ import com.infosupport.ldoc.analyzerj.descriptions.Description;
 import com.infosupport.ldoc.analyzerj.descriptions.ForEachDescription;
 import com.infosupport.ldoc.analyzerj.descriptions.IfDescription;
 import com.infosupport.ldoc.analyzerj.descriptions.IfElseSection;
+import com.infosupport.ldoc.analyzerj.descriptions.InvocationDescription;
 import com.infosupport.ldoc.analyzerj.descriptions.MemberDescription;
 import com.infosupport.ldoc.analyzerj.descriptions.MethodDescription;
 import com.infosupport.ldoc.analyzerj.descriptions.ParameterDescription;
@@ -217,5 +219,13 @@ class AnalysisVisitorTest {
     assertIterableEquals(
         List.of(new AssignmentDescription("john", "=", "paul")),
         parseFragment("john = paul;"));
+  }
+
+  @Test
+  void method_call_expr() {
+    assertIterableEquals(
+        List.of(new InvocationDescription("java.io.PrintStream", "println", List.of(
+            new ArgumentDescription("java.lang.String", "\"Hello!\"")))),
+        parseFragment("System.out.println(\"Hello!\");"));
   }
 }

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/InvocationDescriptionJSONTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/InvocationDescriptionJSONTest.java
@@ -1,0 +1,35 @@
+package com.infosupport.ldoc.analyzerj.descriptions;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class InvocationDescriptionJSONTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void invocation_description_serializes_as_expected() throws IOException {
+    String expected = """
+        {
+          "$type": "LivingDocumentation.InvocationDescription, LivingDocumentation.Descriptions",
+          "ContainingType": "java.util.ArrayList<Integer>",
+          "Name": "add",
+          "Arguments": [
+            {
+              "Type": "int",
+              "Text": "1"
+            }
+          ]
+        }
+        """;
+
+    assertEquals(
+        mapper.readTree(expected),
+        mapper.valueToTree(new InvocationDescription(
+            "java.util.ArrayList<Integer>", "add", List.of(new ArgumentDescription("int", "1")))));
+  }
+}


### PR DESCRIPTION
This is based on #10, which should be merged first.

Oddly enough, we don't seem to store what the scope/receiver/containing expression for a piece of code actually is, so...

```java
a.equals("foo");
b.equals("foo");
```

...look exactly the same in the JSON:

```js
          {
            "$type": "LivingDocumentation.InvocationDescription, LivingDocumentation.Descriptions",
            "Arguments": [
              {
                "Text": "\"foo\"",
                "Type": "java.lang.String"
              }
            ],
            "ContainingType": "java.lang.String",
            "Name": "equals"
          },
          {
            "$type": "LivingDocumentation.InvocationDescription, LivingDocumentation.Descriptions",
            "Arguments": [
              {
                "Text": "\"foo\"",
                "Type": "java.lang.String"
              }
            ],
            "ContainingType": "java.lang.String",
            "Name": "equals"
          }
```

Like with assignment,s these are really expressions, but upstream calls them statements.