### PR TITLE
Add --pretty flag that indents the resulting JSON

### DIFF
--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisJob.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisJob.java
@@ -2,13 +2,6 @@ package com.infosupport.ldoc.analyzerj;
 
 import java.nio.file.Path;
 
-public class AnalysisJob {
+public record AnalysisJob(Path project, Path output, boolean pretty) {
 
-  public final Path project;
-  public final Path output;
-
-  public AnalysisJob(Path project, Path output) {
-    this.project = project;
-    this.output = output;
-  }
 }

--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/Analyzer.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/Analyzer.java
@@ -1,6 +1,7 @@
 package com.infosupport.ldoc.analyzerj;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.github.javaparser.ParseResult;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.resolution.SymbolResolver;
@@ -21,7 +22,7 @@ public class Analyzer {
   }
 
   public void analyze(AnalysisJob job) throws IOException {
-    ProjectRoot projectRoot = new SymbolSolverCollectionStrategy().collect(job.project);
+    ProjectRoot projectRoot = new SymbolSolverCollectionStrategy().collect(job.project());
     List<Description> descriptions = new ArrayList<>();
 
     for (SourceRoot sourceRoot : projectRoot.getSourceRoots()) {
@@ -37,6 +38,9 @@ public class Analyzer {
       }
     }
 
-    objectMapper.writeValue(job.output.toFile(), descriptions);
+    ObjectWriter writer = job.pretty()
+        ? objectMapper.writerWithDefaultPrettyPrinter()
+        : objectMapper.writer();
+    writer.writeValue(job.output().toFile(), descriptions);
   }
 }

--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/Main.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/Main.java
@@ -14,7 +14,8 @@ public class Main {
 
   public static final Options OPTIONS = new Options()
       .addRequiredOption(null, "output", true, "The file path to save the output JSON to.")
-      .addRequiredOption(null, "project", true, "The root directory of the project to analyze.");
+      .addRequiredOption(null, "project", true, "The root directory of the project to analyze.")
+      .addOption("p", "pretty", false, "Indent (pretty-print) JSON output.");
 
   private static AnalysisJob jobFromArgs(String[] args) throws ParseException {
     CommandLineParser parser = new DefaultParser();
@@ -22,7 +23,8 @@ public class Main {
 
     return new AnalysisJob(
         Path.of(commandLine.getOptionValue("project")),
-        Path.of(commandLine.getOptionValue("output")));
+        Path.of(commandLine.getOptionValue("output")),
+        commandLine.hasOption("pretty"));
   }
 
   public static void main(String[] args) throws IOException {


### PR DESCRIPTION
The default is false, following upstream (see [here](https://github.com/eNeRGy164/LivingDocumentation/blob/main/src/LivingDocumentation.Analyzer/Options.cs)).

Pretty rendering:

```json
[ {
  "Type" : 2,
  "FullName" : "com.infosupport.ldoc.analyzerj.descriptions.ReturnDescription",
  "BaseTypes" : [ "com.infosupport.ldoc.analyzerj.descriptions.Description" ],
  "Constructors" : [ {
    "Name" : "ReturnDescription"
  } ],
  "Methods" : [ {
    "ReturnType" : "java.lang.String",
    "Statements" : [ {
      "Expression" : "\"LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions\"",
      "$type" : "LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions"
    } ],
    "Name" : "getType",
    "Attributes" : [ {
      "Type" : "com.fasterxml.jackson.annotation.JsonProperty",
      "Name" : "JsonProperty",
      "Arguments" : [ {
        "Name" : "value",
        "Type" : "java.lang.String",
        "Value" : "\"$type\""
      } ]
    } ]
  } ]
}, 
```

Default rendering:

```json
[{"Type":2,"FullName":"com.infosupport.ldoc.analyzerj.descriptions.ReturnDescription","BaseTypes":["com.infosupport.ldoc.analyzerj.descriptions.Description"],"Constructors":[{"Name":"ReturnDescription"}],"Methods":[{"ReturnType":"java.lang.String","Statements":[{"Expression":"\"LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions\"","$type":"LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions"}],"Name":"getType","Attributes":[{"Type":"com.fasterxml.jackson.annotation.JsonProperty","Name":"JsonProperty","Arguments":[{"Name":"value","Type":"java.lang.String","Value":"\"$type\""}]}]}]},
```