### PR TITLE
Refactor test cases related to comments

### DIFF
--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
@@ -9,7 +9,6 @@ import com.github.javaparser.symbolsolver.JavaSymbolSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import com.infosupport.ldoc.analyzerj.descriptions.*;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -222,33 +221,28 @@ class AnalysisVisitorTest {
 
   @Test
   void comment_tests() {
-    Map<String,String> exampleParams = new LinkedHashMap<>();
-    exampleParams.put("a", "is an object.");
-    exampleParams.put("b", "is a string.");
     assertIterableEquals(
         List.of(new TypeDescription(TypeType.CLASS, "Example", List.of(), null, List.of(), List.of(
             new MethodDescription(
                 new MemberDescription("does"),
                 "Example",
-                new CommentSummaryDescription("this is are the remarks.",
-                    "is Example.", "this method is an example.",
-                    exampleParams, null),
+                new CommentSummaryDescription("These are the remarks.",
+                    "an Example.", "This method is an example.",
+                    Map.of("a", "is an object.", "b", "is a string."), null),
                 List.of(
                     new ParameterDescription("java.lang.Object", "a", List.of()),
                     new ParameterDescription("java.lang.String", "b", List.of())),
                 List.of())), List.of())),
         parse("""
             class Example {
-            /**\s
-            *this method is an example.
-            *this is are the remarks.\s
-            *@param a is an object.
-            *@param b is a string.
-            *@return is Example.
-            */
-            Example does(Object a, String b) {}\s
+              /**
+               * This method is an example. These are the remarks.
+               * @param a is an object.
+               * @param b is a string.
+               * @return an Example.
+               */
+              Example does(Object a, String b) {}
             }
             """));
-
   }
 }

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/CommentSummaryDescriptionJSONTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/CommentSummaryDescriptionJSONTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -14,25 +13,24 @@ public class CommentSummaryDescriptionJSONTest {
   private final ObjectMapper mapper = new ObjectMapper();
 
   @Test
-  void Check_for_comments() throws IOException {
-    // Create a Map<String, String>
-    Map<String, String> keyValueMap = new LinkedHashMap<>();
-
-    // Add key-value pairs to the map
-    keyValueMap.put("N", "first integer value");
-    keyValueMap.put("Y", "second integer value");
-
+  void comment_summary_description_serializes_as_expected() throws IOException {
     String example = """
         {
           "Remarks": "tread carefully.",
           "Returns": "An integer.",
           "Summary": "add two values",
-          "Params": {\s
-             "N": "first integer value" ,
-             "Y": "second integer value" }
+          "Params": {
+            "N": "first integer value",
+            "Y": "second integer value"
+          }
         }
         """;
-    assertEquals(mapper.readTree(example), mapper.valueToTree(
-        new CommentSummaryDescription("tread carefully.", "An integer.", "add two values", keyValueMap, null)));
+    assertEquals(
+        mapper.readTree(example),
+        mapper.valueToTree(
+          new CommentSummaryDescription(
+              "tread carefully.", "An integer.", "add two values",
+              Map.of("N", "first integer value", "Y", "second integer value"),
+              null)));
   }
 }

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/MethodDescriptionJSONTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/MethodDescriptionJSONTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -16,13 +15,6 @@ class MethodDescriptionJSONTest {
 
   @Test
   void method_description_serializes_as_expected() throws IOException {
-    // Create a Map<String, String>
-    Map<String, String> keyValueMap = new LinkedHashMap<>();
-
-    // Add key-value pairs to the map
-    keyValueMap.put("N", "first integer value");
-    keyValueMap.put("Y", "second integer value");
-
     assertEquals(
         mapper.readTree("{\"Name\": \"aap\", \"ReturnType\": \"Noot\"}"),
         mapper.valueToTree(
@@ -33,12 +25,13 @@ class MethodDescriptionJSONTest {
               "Name": "mies",
               "ReturnType": "org.example.Gans",
               "DocumentationComments": {
-                "Remarks": "tread carefully.",
-                  "Returns": "An integer.",
-                  "Summary": "add two values",
-                  "Params": {
-                     "N": "first integer value" ,
-                     "Y": "second integer value" }
+                "Remarks": "Tread carefully.",
+                "Returns": "An integer.",
+                "Summary": "Add two values.",
+                "Params": {
+                   "N": "first integer value" ,
+                   "Y": "second integer value"
+                }
               },
               "Parameters": [
                 { "Name": "gijs", "Type": "Zeef" },
@@ -52,7 +45,14 @@ class MethodDescriptionJSONTest {
             new MethodDescription(
                 new MemberDescription("mies"),
                 "org.example.Gans",
-                    new CommentSummaryDescription("tread carefully.","An integer.","add two values",keyValueMap,null),
+                    new CommentSummaryDescription(
+                        "Tread carefully.",
+                        "An integer.",
+                        "Add two values.",
+                        Map.of(
+                            "N", "first integer value",
+                            "Y", "second integer value"),
+                        null),
                 List.of(
                     new ParameterDescription("Zeef", "gijs", List.of()),
                     new ParameterDescription("Muis", "jip", List.of())),


### PR DESCRIPTION
- Use `Map.of` in tests for consistency with usage of `List.of`
- Capitalize and indent examples

In #29, it was mentioned that `Map.of` could not be used because an ordering needed to be preserved, but since we compare trees (from `readTree`, `valueToTree`) instead of strings, ordering already does not matter.