### PR TITLE
Loosen type restriction on IfDescription.sections

### DIFF
--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
@@ -155,7 +155,7 @@ public class AnalysisVisitor extends GenericListVisitorAdapter<Description, Anal
 
   @Override
   public List<Description> visit(IfStmt n, Analyzer arg) {
-    List<IfElseSection> sections = new ArrayList<>();
+    List<Description> sections = new ArrayList<>();
     String condition = n.getCondition().toString();
     List<Description> consequent = n.getThenStmt().accept(this, arg);
     sections.add(new IfElseSection(condition, consequent));

--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/IfDescription.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/IfDescription.java
@@ -8,7 +8,7 @@ import java.util.List;
 public record IfDescription(
     @JsonProperty("Sections")
     @JsonInclude(Include.NON_EMPTY)
-    List<IfElseSection> sections
+    List<Description> sections
 ) implements Description {
 
   @JsonProperty("$type")


### PR DESCRIPTION
The linked issue suggests tightening all other description records, but given that the Visitor class traffics in List<Description> a lot, making it consistent in this direction is a smaller change.

Closes #27.