### PR TITLE
Do not visit catch clause exception specifications

### DIFF
--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
@@ -18,6 +18,7 @@ import com.github.javaparser.ast.expr.MemberValuePair;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NormalAnnotationExpr;
 import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
+import com.github.javaparser.ast.stmt.CatchClause;
 import com.github.javaparser.ast.stmt.ForEachStmt;
 import com.github.javaparser.ast.stmt.IfStmt;
 import com.github.javaparser.ast.stmt.ReturnStmt;
@@ -206,6 +207,13 @@ public class AnalysisVisitor extends GenericListVisitorAdapter<Description, Anal
     return List.of(new InvocationDescription(
         n.getScope().map(s -> resolver.calculateType(s).describe()).orElse("?"),
         n.getNameAsString(), arguments));
+  }
+
+  @Override
+  public List<Description> visit(CatchClause n, Analyzer arg) {
+    // Unlike the method we're overriding, we ignore catch clause comments and parameters.
+    List<Description> out = n.getBody().accept(this, arg);
+    return (out != null) ? out : List.of();
   }
 
   @Override

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
@@ -220,6 +220,14 @@ class AnalysisVisitorTest {
   }
 
   @Test
+  void catch_clause_parameters_ignored() {
+    // Regression test for issue #34. The "Exception e" should not be regarded as a parameter.
+    assertIterableEquals(
+        List.of(new ReturnDescription("1")),
+        parseFragment("try { } catch (Exception e) { return 1; }"));
+  }
+
+  @Test
   void comment_tests() {
     assertIterableEquals(
         List.of(new TypeDescription(TypeType.CLASS, "Example", List.of(), null, List.of(), List.of(


### PR DESCRIPTION
These are treated as parameters by Javaparser, but not by us.

Fixes #34.