### PR TITLE
Work around MemberValuePair not having a SymbolResolver

### DIFF
--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
@@ -139,7 +139,7 @@ public class AnalysisVisitor extends GenericListVisitorAdapter<Description, Anal
   @Override
   public List<Description> visit(MemberValuePair n, Analyzer arg) {
     return List.of(new AttributeArgumentDescription(n.getNameAsString(),
-        n.getValue().calculateResolvedType().describe(), n.getValue().toString()));
+        resolver.calculateType(n.getValue()).describe(), n.getValue().toString()));
   }
 
   @Override


### PR DESCRIPTION
Fixes #38.

We discussed adding a test case that tests the analyzer by analyzing the analyzer - that's not in here, but I did confirm that with this change, the analyzer can analyze itself again.