### PR TITLE
Add basic Maven plugin and usage example

### DIFF
--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisJob.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisJob.java
@@ -1,7 +1,8 @@
 package com.infosupport.ldoc.analyzerj;
 
 import java.nio.file.Path;
+import java.util.List;
 
-public record AnalysisJob(Path project, Path output, boolean pretty) {
+public record AnalysisJob(Path project, Path output, List<String> classpath, boolean pretty) {
 
 }

--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/Analyzer.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/Analyzer.java
@@ -3,10 +3,14 @@ package com.infosupport.ldoc.analyzerj;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.github.javaparser.ParseResult;
+import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.resolution.SymbolResolver;
+import com.github.javaparser.resolution.TypeSolver;
+import com.github.javaparser.symbolsolver.JavaSymbolSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.TypeSolverBuilder;
 import com.github.javaparser.symbolsolver.utils.SymbolSolverCollectionStrategy;
-import com.github.javaparser.utils.ProjectRoot;
+import com.github.javaparser.utils.CollectionStrategy;
 import com.github.javaparser.utils.SourceRoot;
 import com.infosupport.ldoc.analyzerj.descriptions.Description;
 import java.io.IOException;
@@ -21,11 +25,25 @@ public class Analyzer {
     this.objectMapper = objectMapper;
   }
 
+  private TypeSolver typeSolverFor(AnalysisJob job) throws IOException {
+    var typeSolverBuilder = new TypeSolverBuilder().withCurrentJRE().withSourceCode(job.project());
+
+    for (String cp : job.classpath()) {
+      if (cp.toLowerCase().endsWith(".jar")) {
+        typeSolverBuilder = typeSolverBuilder.withJAR(cp);
+      }
+    }
+
+    return typeSolverBuilder.build();
+  }
+
   public void analyze(AnalysisJob job) throws IOException {
-    ProjectRoot projectRoot = new SymbolSolverCollectionStrategy().collect(job.project());
+    ParserConfiguration parserConfiguration = new ParserConfiguration()
+        .setSymbolResolver(new JavaSymbolSolver(typeSolverFor(job)));
+    CollectionStrategy strategy = new SymbolSolverCollectionStrategy(parserConfiguration);
     List<Description> descriptions = new ArrayList<>();
 
-    for (SourceRoot sourceRoot : projectRoot.getSourceRoots()) {
+    for (SourceRoot sourceRoot : strategy.collect(job.project()).getSourceRoots()) {
       List<ParseResult<CompilationUnit>> results = sourceRoot.tryToParse();
       SymbolResolver solver = sourceRoot.getParserConfiguration().getSymbolResolver().orElseThrow();
 

--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/Main.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/Main.java
@@ -3,6 +3,7 @@ package com.infosupport.ldoc.analyzerj;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -27,6 +28,7 @@ public class Main {
     return new AnalysisJob(
         Path.of(commandLine.getOptionValue("project")),
         Path.of(commandLine.getOptionValue("output")),
+        List.of(),
         commandLine.hasOption("pretty"));
   }
 

--- a/ldj-maven-plugin-example/pom.xml
+++ b/ldj-maven-plugin-example/pom.xml
@@ -1,0 +1,45 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>ldj-maven-plugin-example</artifactId>
+
+  <parent>
+    <groupId>com.infosupport.livingdocumentation</groupId>
+    <artifactId>livingdocumentation-java</artifactId>
+    <version>1-SNAPSHOT</version>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.7</version>
+    </dependency>
+  </dependencies>
+
+  <properties>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.infosupport.livingdocumentation</groupId>
+        <artifactId>ldj-maven-plugin</artifactId>
+        <version>1-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>livingdocumentation</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/ldj-maven-plugin-example/pom.xml
+++ b/ldj-maven-plugin-example/pom.xml
@@ -31,14 +31,6 @@
         <groupId>com.infosupport.livingdocumentation</groupId>
         <artifactId>ldj-maven-plugin</artifactId>
         <version>1-SNAPSHOT</version>
-        <executions>
-          <execution>
-            <phase>process-sources</phase>
-            <goals>
-              <goal>livingdocumentation</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/ldj-maven-plugin-example/pom.xml
+++ b/ldj-maven-plugin-example/pom.xml
@@ -31,6 +31,13 @@
         <groupId>com.infosupport.livingdocumentation</groupId>
         <artifactId>ldj-maven-plugin</artifactId>
         <version>1-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>livingdocumentation</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/ldj-maven-plugin-example/src/main/java/org/example/ExampleClass.java
+++ b/ldj-maven-plugin-example/src/main/java/org/example/ExampleClass.java
@@ -1,0 +1,13 @@
+package org.example;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ExampleClass implements ExampleInterface {
+
+  private static final Logger logger = LoggerFactory.getLogger(ExampleClass.class);
+
+  public static void main(String[] args) {
+    logger.atInfo().log("Hello, world!");
+  }
+}

--- a/ldj-maven-plugin-example/src/main/java/org/example/ExampleInterface.java
+++ b/ldj-maven-plugin-example/src/main/java/org/example/ExampleInterface.java
@@ -1,0 +1,5 @@
+package org.example;
+
+public interface ExampleInterface {
+
+}

--- a/ldj-maven-plugin/pom.xml
+++ b/ldj-maven-plugin/pom.xml
@@ -1,0 +1,72 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>ldj-maven-plugin</artifactId>
+
+  <packaging>maven-plugin</packaging>
+
+  <parent>
+    <groupId>com.infosupport.livingdocumentation</groupId>
+    <artifactId>livingdocumentation-java</artifactId>
+    <version>1-SNAPSHOT</version>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.infosupport.livingdocumentation</groupId>
+      <artifactId>analyzer-java</artifactId>
+      <version>1-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.15.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <version>3.8.6</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>3.9.3</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.9.0</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <properties>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-plugin-plugin</artifactId>
+          <version>3.9.0</version>
+          <executions>
+            <execution>
+              <id>help-mojo</id>
+              <goals>
+                <goal>helpmojo</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/ldj-maven-plugin/src/main/java/com/infosupport/ldoc/mavenplugin/LivingDocumentationMojo.java
+++ b/ldj-maven-plugin/src/main/java/com/infosupport/ldoc/mavenplugin/LivingDocumentationMojo.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.infosupport.ldoc.analyzerj.AnalysisJob;
 import com.infosupport.ldoc.analyzerj.Analyzer;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
@@ -12,12 +11,16 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 
-@Mojo(name = "livingdocumentation", requiresDependencyResolution = ResolutionScope.COMPILE)
+@Mojo(
+    name = "livingdocumentation",
+    requiresDependencyResolution = ResolutionScope.COMPILE,
+    defaultPhase = LifecyclePhase.COMPILE)
 public class LivingDocumentationMojo extends AbstractMojo {
 
   @Parameter(readonly = true, defaultValue = "${project}")
@@ -32,7 +35,6 @@ public class LivingDocumentationMojo extends AbstractMojo {
       Path proj = Path.of(project.getBuild().getSourceDirectory());
       Path target = Path.of(project.getBuild().getDirectory());
       Path out = target.resolve("livingdocumentation.json");
-      Files.createDirectories(target);
 
       List<String> classpath = project.getCompileClasspathElements();
 

--- a/ldj-maven-plugin/src/main/java/com/infosupport/ldoc/mavenplugin/LivingDocumentationMojo.java
+++ b/ldj-maven-plugin/src/main/java/com/infosupport/ldoc/mavenplugin/LivingDocumentationMojo.java
@@ -1,0 +1,48 @@
+package com.infosupport.ldoc.mavenplugin;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.infosupport.ldoc.analyzerj.AnalysisJob;
+import com.infosupport.ldoc.analyzerj.Analyzer;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.apache.maven.artifact.DependencyResolutionRequiredException;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+
+@Mojo(name = "livingdocumentation", requiresDependencyResolution = ResolutionScope.COMPILE)
+public class LivingDocumentationMojo extends AbstractMojo {
+
+  @Parameter(readonly = true, defaultValue = "${project}")
+  private MavenProject project;
+
+  @Override
+  public void execute() throws MojoExecutionException, MojoFailureException {
+    Analyzer a = new Analyzer(new ObjectMapper());
+    Log log = getLog();
+
+    try {
+      Path proj = Path.of(project.getBuild().getSourceDirectory());
+      Path target = Path.of(project.getBuild().getDirectory());
+      Path out = target.resolve("livingdocumentation.json");
+      Files.createDirectories(target);
+
+      List<String> classpath = project.getCompileClasspathElements();
+
+      log.info("Source path: " + proj);
+      log.info("Output path: " + out);
+      log.info("Class path:  " + String.join(":", classpath));
+
+      a.analyze(new AnalysisJob(proj, out, classpath, true));
+    } catch (IOException | DependencyResolutionRequiredException e) {
+      throw new MojoFailureException(e);
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -10,5 +10,7 @@
 
   <modules>
     <module>analyzer-java</module>
+    <module>ldj-maven-plugin</module>
+    <module>ldj-maven-plugin-example</module>
   </modules>
 </project>


### PR DESCRIPTION
The plugin is bound to the `compile` Maven phase in a project and will then generate a `livingdocumentation.json` file in the target directory.

Any JARs that are part of the compilation classpath are added to the parser to resolve type information.

The current plugin is not really configurable; it always does the above thing. It's pretty minimal. However, it could form the beginning of #44.