### PR TITLE
Process additional feedback on #23

### DIFF
--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
@@ -1,6 +1,5 @@
 package com.infosupport.ldoc.analyzerj;
 
-import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.BodyDeclaration;
@@ -59,8 +58,8 @@ public class AnalysisVisitor extends GenericListVisitorAdapter<Description, Anal
   }
 
   /** Computes an OR-combined LivingDocumentation bitmask for a NodeList of JavaParser Modifiers. */
-  private int combine(NodeList<Modifier> modifiers) {
-    return modifiers.stream().mapToInt(m -> Modifiers.valueOf(m).mask()).reduce(0, (a, b) -> a | b);
+  private int combine(NodeList<com.github.javaparser.ast.Modifier> modifiers) {
+    return modifiers.stream().mapToInt(m -> Modifier.valueOf(m).mask()).reduce(0, (a, b) -> a | b);
   }
 
   @Override

--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/Modifier.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/Modifier.java
@@ -8,7 +8,7 @@ import com.github.javaparser.ast.body.TypeDeclaration;
  * example 'async') or Java (like 'strictfp') are not included, but could be in the future. Values
  * (bitmasks) are taken from <code>LivingDocumentation.Abstractions/Modifier.cs</code>.
  */
-public enum Modifiers {
+public enum Modifier {
   NONE(0),
   PUBLIC(1 << 1),
   PRIVATE(1 << 2),
@@ -21,7 +21,7 @@ public enum Modifiers {
 
   private final int mask;
 
-  Modifiers(int mask) {
+  Modifier(int mask) {
     this.mask = mask;
   }
 
@@ -29,7 +29,7 @@ public enum Modifiers {
     return mask;
   }
 
-  public static Modifiers valueOf(com.github.javaparser.ast.Modifier modifier) {
+  public static Modifier valueOf(com.github.javaparser.ast.Modifier modifier) {
     boolean onType = modifier.getParentNode().map(n -> n instanceof TypeDeclaration).orElse(false);
 
     return switch (modifier.getKeyword()) {

--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/TypeDescription.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/TypeDescription.java
@@ -45,7 +45,7 @@ public record TypeDescription(
   }
 
   public TypeDescription(TypeType type, String fullName, List<String> baseTypes) {
-    this(type, Modifiers.NONE.mask(), fullName, baseTypes, null, List.of(), List.of(), List.of());
+    this(type, Modifier.NONE.mask(), fullName, baseTypes, null, List.of(), List.of(), List.of());
   }
 
 }

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
@@ -274,16 +274,16 @@ class AnalysisVisitorTest {
     var type = (TypeDescription)parsed.get(0);
     assertEquals(
         type.modifiers(),
-        Modifiers.PUBLIC.mask() | Modifiers.SEALED.mask());
+        Modifier.PUBLIC.mask() | Modifier.SEALED.mask());
 
     var consume = (MethodDescription)type.methods().get(0);
     assertEquals(
         consume.member().modifiers(),
-        Modifiers.PRIVATE.mask());
+        Modifier.PRIVATE.mask());
 
     var prepare = (MethodDescription)type.methods().get(1);
     assertEquals(
         prepare.member().modifiers(),
-        Modifiers.PUBLIC.mask() | Modifiers.STATIC.mask());
+        Modifier.PUBLIC.mask() | Modifier.STATIC.mask());
   }
 }

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
@@ -273,17 +273,17 @@ class AnalysisVisitorTest {
 
     var type = (TypeDescription)parsed.get(0);
     assertEquals(
-        type.modifiers(),
-        Modifier.PUBLIC.mask() | Modifier.SEALED.mask());
+        Modifier.PUBLIC.mask() | Modifier.SEALED.mask(),
+        type.modifiers());
 
     var consume = (MethodDescription)type.methods().get(0);
     assertEquals(
-        consume.member().modifiers(),
-        Modifier.PRIVATE.mask());
+        Modifier.PRIVATE.mask(),
+        consume.member().modifiers());
 
     var prepare = (MethodDescription)type.methods().get(1);
     assertEquals(
-        prepare.member().modifiers(),
-        Modifier.PUBLIC.mask() | Modifier.STATIC.mask());
+        Modifier.PUBLIC.mask() | Modifier.STATIC.mask(),
+        prepare.member().modifiers());
   }
 }

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/MethodDescriptionJSONTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/MethodDescriptionJSONTest.java
@@ -19,7 +19,7 @@ class MethodDescriptionJSONTest {
         mapper.readTree("{\"Modifiers\": 4, \"Name\": \"aap\", \"ReturnType\": \"Noot\"}"),
         mapper.valueToTree(
             new MethodDescription(
-                new MemberDescription("aap", Modifiers.PRIVATE.mask(), List.of()),
+                new MemberDescription("aap", Modifier.PRIVATE.mask(), List.of()),
                 "Noot", null, List.of(), List.of())));
 
     String example = """

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/ModifierTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/ModifierTest.java
@@ -2,44 +2,43 @@ package com.infosupport.ldoc.analyzerj.descriptions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.type.PrimitiveType;
 import org.junit.jupiter.api.Test;
 
-class ModifiersTest {
+class ModifierTest {
 
   @Test
   void modifier_with_no_equivalent_returns_none() {
     assertEquals(
-        Modifiers.NONE,
-        Modifiers.valueOf(Modifier.strictfpModifier()));
+        Modifier.NONE,
+        Modifier.valueOf(com.github.javaparser.ast.Modifier.strictfpModifier()));
   }
 
   @Test
   void modifier_with_direct_equivalent_returns_equivalent() {
     assertEquals(
-        Modifiers.PRIVATE,
-        Modifiers.valueOf(Modifier.privateModifier()));
+        Modifier.PRIVATE,
+        Modifier.valueOf(com.github.javaparser.ast.Modifier.privateModifier()));
   }
 
   @Test
   void modifier_final_depends_on_context() {
     // When the Java final modifier appears on a class, the meaning is closest to C# 'sealed'.
     ClassOrInterfaceDeclaration exampleClass = new ClassOrInterfaceDeclaration(
-        NodeList.nodeList(Modifier.finalModifier()), false, "Example");
+        NodeList.nodeList(com.github.javaparser.ast.Modifier.finalModifier()), false, "Example");
     assertEquals(
-        Modifiers.SEALED,
-        Modifiers.valueOf(exampleClass.getModifiers().getFirst().orElseThrow()));
+        Modifier.SEALED,
+        Modifier.valueOf(exampleClass.getModifiers().getFirst().orElseThrow()));
 
     // When the Java final modifier appears on a field, the meaning is closest to C# 'readonly'.
     FieldDeclaration exampleField = new FieldDeclaration(
-        NodeList.nodeList(Modifier.finalModifier()),
+        NodeList.nodeList(com.github.javaparser.ast.Modifier.finalModifier()),
         PrimitiveType.intType(), "someField");
     assertEquals(
-        Modifiers.READONLY,
-        Modifiers.valueOf(exampleField.getModifiers().getFirst().orElseThrow()));
+        Modifier.READONLY,
+        Modifier.valueOf(exampleField.getModifiers().getFirst().orElseThrow()));
   }
 }

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/TypeDescriptionJSONTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/TypeDescriptionJSONTest.java
@@ -37,7 +37,7 @@ class TypeDescriptionJSONTest {
         mapper.readTree("{\"Modifiers\": 1026, \"FullName\": \"Wilma\"}"),
         mapper.valueToTree(new TypeDescription(
             TypeType.CLASS,
-            Modifiers.PUBLIC.mask() | Modifiers.SEALED.mask(),
+            Modifier.PUBLIC.mask() | Modifier.SEALED.mask(),
             "Wilma",
             List.of(),
             null,


### PR DESCRIPTION
This renames the `Modifiers` enum to `Modifier` and swaps some `assertEquals` arguments.