### PR TITLE
Add checkstyle Maven plugin

### DIFF
--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
@@ -9,7 +9,7 @@ import com.github.javaparser.ast.body.EnumDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.body.RecordDeclaration;
-import com.github.javaparser.ast.comments.*;
+import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.AssignExpr;
 import com.github.javaparser.ast.expr.Expression;
@@ -30,10 +30,31 @@ import com.github.javaparser.ast.visitor.GenericListVisitorAdapter;
 import com.github.javaparser.resolution.SymbolResolver;
 import com.github.javaparser.resolution.declarations.ResolvedAnnotationDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
-import com.infosupport.ldoc.analyzerj.descriptions.*;
-import com.infosupport.ldoc.analyzerj.helperMethods.CommentHelperMethods;
-
-import java.util.*;
+import com.infosupport.ldoc.analyzerj.descriptions.ArgumentDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.AssignmentDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.AttributeArgumentDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.AttributeDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.CommentSummaryDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.ConstructorDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.Description;
+import com.infosupport.ldoc.analyzerj.descriptions.ForEachDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.IfDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.IfElseSection;
+import com.infosupport.ldoc.analyzerj.descriptions.InvocationDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.MemberDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.MethodDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.Modifier;
+import com.infosupport.ldoc.analyzerj.descriptions.ParameterDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.ReturnDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.SwitchDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.SwitchSection;
+import com.infosupport.ldoc.analyzerj.descriptions.TypeDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.TypeType;
+import com.infosupport.ldoc.analyzerj.helpermethods.CommentHelperMethods;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 
 public class AnalysisVisitor extends GenericListVisitorAdapter<Description, Analyzer> {
@@ -60,6 +81,11 @@ public class AnalysisVisitor extends GenericListVisitorAdapter<Description, Anal
   /** Computes an OR-combined LivingDocumentation bitmask for a NodeList of JavaParser Modifiers. */
   private int combine(NodeList<com.github.javaparser.ast.Modifier> modifiers) {
     return modifiers.stream().mapToInt(m -> Modifier.valueOf(m).mask()).reduce(0, (a, b) -> a | b);
+  }
+
+  private List<Description> visitAnnotation(AnnotationExpr n, List<Description> args) {
+    var type = resolver.resolveDeclaration(n, ResolvedAnnotationDeclaration.class);
+    return List.of(new AttributeDescription(type.getQualifiedName(), n.getNameAsString(), args));
   }
 
   @Override
@@ -128,11 +154,6 @@ public class AnalysisVisitor extends GenericListVisitorAdapter<Description, Anal
   public List<Description> visit(Parameter n, Analyzer arg) {
     return List.of(new ParameterDescription(resolve(n.getType()), n.getNameAsString(),
         visit(n.getAnnotations(), arg)));
-  }
-
-  private List<Description> visitAnnotation(AnnotationExpr n, List<Description> args) {
-    var type = resolver.resolveDeclaration(n, ResolvedAnnotationDeclaration.class);
-    return List.of(new AttributeDescription(type.getQualifiedName(), n.getNameAsString(), args));
   }
 
   @Override

--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/CommentSummaryDescription.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/CommentSummaryDescription.java
@@ -3,7 +3,6 @@ package com.infosupport.ldoc.analyzerj.descriptions;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.Map;
 
 public record CommentSummaryDescription(

--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/MethodDescription.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/MethodDescription.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
-
-
 import java.util.List;
 
 public record MethodDescription(

--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/TypeDescription.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/TypeDescription.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.List;
 
 public record TypeDescription(

--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/helpermethods/CommentHelperMethods.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/helpermethods/CommentHelperMethods.java
@@ -1,7 +1,6 @@
-package com.infosupport.ldoc.analyzerj.helperMethods;
+package com.infosupport.ldoc.analyzerj.helpermethods;
 
 import com.github.javaparser.ast.comments.JavadocComment;
-
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -57,6 +56,6 @@ public class CommentHelperMethods {
 
   private static String extractInnerValues(String input) {
     // Return the content inside angle brackets
-    return input.substring(1,input.length()-1);
+    return input.substring(1, input.length() - 1);
   }
 }

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
@@ -1,17 +1,36 @@
 package com.infosupport.ldoc.analyzerj;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.resolution.SymbolResolver;
 import com.github.javaparser.symbolsolver.JavaSymbolSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
-import com.infosupport.ldoc.analyzerj.descriptions.*;
-
+import com.infosupport.ldoc.analyzerj.descriptions.ArgumentDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.AssignmentDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.AttributeArgumentDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.AttributeDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.CommentSummaryDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.ConstructorDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.Description;
+import com.infosupport.ldoc.analyzerj.descriptions.ForEachDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.IfDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.IfElseSection;
+import com.infosupport.ldoc.analyzerj.descriptions.InvocationDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.MemberDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.MethodDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.Modifier;
+import com.infosupport.ldoc.analyzerj.descriptions.ParameterDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.ReturnDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.SwitchDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.SwitchSection;
+import com.infosupport.ldoc.analyzerj.descriptions.TypeDescription;
+import com.infosupport.ldoc.analyzerj.descriptions.TypeType;
 import java.util.List;
 import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 
 class AnalysisVisitorTest {
@@ -240,8 +259,11 @@ class AnalysisVisitorTest {
                     "Example",
                     new CommentSummaryDescription("These are the remarks.",
                         "an Example.", "This method is an example.main<>.",
-                        Map.of("a", "is an object.", "b", "is a string.","Map<input>", "map of strings."),
-                    Map.of("L", "is a list.","L<C>","list of characters.")),
+                        Map.of(
+                            "a", "is an object.",
+                            "b", "is a string.",
+                            "Map<input>", "map of strings."),
+                        Map.of("L", "is a list.", "L<C>", "list of characters.")),
                     List.of(
                         new ParameterDescription("java.lang.Object", "a", List.of()),
                         new ParameterDescription("java.lang.String", "b", List.of())),
@@ -272,17 +294,17 @@ class AnalysisVisitorTest {
         }
         """);
 
-    var type = (TypeDescription)parsed.get(0);
+    var type = (TypeDescription) parsed.get(0);
     assertEquals(
         Modifier.PUBLIC.mask() | Modifier.SEALED.mask(),
         type.modifiers());
 
-    var consume = (MethodDescription)type.methods().get(0);
+    var consume = (MethodDescription) type.methods().get(0);
     assertEquals(
         Modifier.PRIVATE.mask(),
         consume.member().modifiers());
 
-    var prepare = (MethodDescription)type.methods().get(1);
+    var prepare = (MethodDescription) type.methods().get(1);
     assertEquals(
         Modifier.PUBLIC.mask() | Modifier.STATIC.mask(),
         prepare.member().modifiers());

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/AssignmentDescriptionJsonTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/AssignmentDescriptionJsonTest.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
-class AssignmentDescriptionJSONTest {
+class AssignmentDescriptionJsonTest {
 
   private final ObjectMapper mapper = new ObjectMapper();
 

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/AttributeDescriptionJsonTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/AttributeDescriptionJsonTest.java
@@ -1,13 +1,13 @@
 package com.infosupport.ldoc.analyzerj.descriptions;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-class AttributeDescriptionJSONTest {
+class AttributeDescriptionJsonTest {
 
   private final ObjectMapper mapper = new ObjectMapper();
 

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/CommentSummaryDescriptionJsonTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/CommentSummaryDescriptionJsonTest.java
@@ -1,14 +1,13 @@
 package com.infosupport.ldoc.analyzerj.descriptions;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import java.util.Map;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class CommentSummaryDescriptionJSONTest {
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class CommentSummaryDescriptionJsonTest {
 
   private final ObjectMapper mapper = new ObjectMapper();
 

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/ConstructorDescriptionJsonTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/ConstructorDescriptionJsonTest.java
@@ -1,13 +1,13 @@
 package com.infosupport.ldoc.analyzerj.descriptions;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-class ConstructorDescriptionJSONTest {
+class ConstructorDescriptionJsonTest {
 
   private final ObjectMapper mapper = new ObjectMapper();
 

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/ForEachDescriptionJsonTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/ForEachDescriptionJsonTest.java
@@ -1,13 +1,13 @@
 package com.infosupport.ldoc.analyzerj.descriptions;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-class ForEachDescriptionJSONTest {
+class ForEachDescriptionJsonTest {
 
   private final ObjectMapper mapper = new ObjectMapper();
 

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/IfDescriptionJsonTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/IfDescriptionJsonTest.java
@@ -1,13 +1,13 @@
 package com.infosupport.ldoc.analyzerj.descriptions;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-class IfDescriptionJSONTest {
+class IfDescriptionJsonTest {
 
   private final ObjectMapper mapper = new ObjectMapper();
 
@@ -19,23 +19,19 @@ class IfDescriptionJSONTest {
           "Sections": [
             {
               "Condition": "true",
-              "Statements": [
-                {
-                  "$type": "LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions",
-                  "Expression": "1"
-                }
-              ]
+              "Statements": [{
+                "$type": "LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions",
+                "Expression": "1"
+              }]
             },
             {
               "Condition": "false"
             },
             {
-              "Statements": [
-                {
-                  "$type": "LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions",
-                  "Expression": "2"
-                }
-              ]
+              "Statements": [{
+                "$type": "LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions",
+                "Expression": "2"
+              }]
             }
           ]
         }

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/InvocationDescriptionJsonTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/InvocationDescriptionJsonTest.java
@@ -1,13 +1,13 @@
 package com.infosupport.ldoc.analyzerj.descriptions;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-class InvocationDescriptionJSONTest {
+class InvocationDescriptionJsonTest {
 
   private final ObjectMapper mapper = new ObjectMapper();
 

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/MethodDescriptionJsonTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/MethodDescriptionJsonTest.java
@@ -1,15 +1,14 @@
 package com.infosupport.ldoc.analyzerj.descriptions;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 
-class MethodDescriptionJSONTest {
+class MethodDescriptionJsonTest {
 
   private final ObjectMapper mapper = new ObjectMapper();
 

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/ReturnDescriptionJsonTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/ReturnDescriptionJsonTest.java
@@ -1,12 +1,12 @@
 package com.infosupport.ldoc.analyzerj.descriptions;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
-class ReturnDescriptionJSONTest {
+class ReturnDescriptionJsonTest {
 
   private final ObjectMapper mapper = new ObjectMapper();
 

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/SwitchDescriptionJsonTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/SwitchDescriptionJsonTest.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-class SwitchDescriptionJSONTest {
+class SwitchDescriptionJsonTest {
 
   private final ObjectMapper mapper = new ObjectMapper();
 

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/TypeDescriptionJsonTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/TypeDescriptionJsonTest.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-class TypeDescriptionJSONTest {
+class TypeDescriptionJsonTest {
 
   private final ObjectMapper mapper = new ObjectMapper();
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,4 +14,31 @@
     <module>ldj-maven-plugin</module>
     <module>ldj-maven-plugin-example</module>
   </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>3.2.2</version>
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <configuration>
+              <configLocation>google_checks.xml</configLocation>
+              <includeTestSourceDirectory>true</includeTestSourceDirectory>
+              <consoleOutput>true</consoleOutput>
+              <failOnViolation>true</failOnViolation>
+              <violationSeverity>warning</violationSeverity>
+              <violationIgnore>MissingJavadocType,MissingJavadocMethod</violationIgnore>
+              <linkXRef>false</linkXRef>
+            </configuration>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
We discussed this at the last meeting - I was worried that getting something like this working and succeeding would be complicated, but it looks like it's actually not too bad: it doesn't need much configuration, and the suggestions it makes are sensible. So if you guys agree we can use this to enforce some things.

This uses Google style as a base, and fails the build if something is wrong.

Some of these checks were actually failing, so this PR fixes those (mostly imports and test class names).

The style guide (in 7.3.1) gives an exception that you don't have to put a Javadoc comment on "simple, obvious methods like getFoo" - of course, the machine can't really discern what is simple or obvious, so this configuration disables that check; it needs to be checked during code review instead.