### PR TITLE
Add Javadoc method comments to some public methods and classes

### DIFF
--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisJob.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisJob.java
@@ -3,6 +3,14 @@ package com.infosupport.ldoc.analyzerj;
 import java.nio.file.Path;
 import java.util.List;
 
+/**
+ * Parameter object describing a project to be analyzed.
+ *
+ * @param project   directory to scan for source files, like <code>/path/to/src/main/java</code>
+ * @param output    file path where the resulting JSON should be written
+ * @param classpath absolute paths to JARs that are added to the classpath for type resolution
+ * @param pretty    whether to indent the resulting JSON
+ */
 public record AnalysisJob(Path project, Path output, List<String> classpath, boolean pretty) {
 
 }

--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/Analyzer.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/Analyzer.java
@@ -17,14 +17,24 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Analyzer executes {@link AnalysisJob} instances. It walks the given source directory, parses each
+ * Java file, then uses the {@link AnalysisVisitor} to combine the resulting parse trees into a JSON
+ * output that follows LivingDocumentation conventions.
+ */
 public class Analyzer {
 
   private final ObjectMapper objectMapper;
 
+  /** Constructs an Analyzer with the given Jackson ObjectMapper. */
   public Analyzer(ObjectMapper objectMapper) {
     this.objectMapper = objectMapper;
   }
 
+  /**
+   * Returns a type solver that can resolve from neighboring source code, the classpath provided in
+   * the {@link AnalysisJob}, and by reflection (which is required to resolve types like Object).
+   */
   private TypeSolver typeSolverFor(AnalysisJob job) throws IOException {
     var typeSolverBuilder = new TypeSolverBuilder();
 
@@ -37,6 +47,7 @@ public class Analyzer {
     return typeSolverBuilder.withCurrentClassloader().withSourceCode(job.project()).build();
   }
 
+  /** Execute the given job. An exception is thrown if a file can not be read or parsed. */
   public void analyze(AnalysisJob job) throws IOException {
     ParserConfiguration parserConfiguration = new ParserConfiguration()
         .setSymbolResolver(new JavaSymbolSolver(typeSolverFor(job)));

--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/Main.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/Main.java
@@ -11,6 +11,7 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
+/** Command-line entry point to use the analyzer standalone (not through the Maven plugin). */
 public class Main {
 
   private static Options options() {
@@ -32,6 +33,7 @@ public class Main {
         commandLine.hasOption("pretty"));
   }
 
+  /** Entry point. */
   public static void main(String[] args) throws IOException {
     ObjectMapper objectMapper = new ObjectMapper();
     Analyzer analyzer = new Analyzer(objectMapper);

--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/helpermethods/CommentHelperMethods.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/helpermethods/CommentHelperMethods.java
@@ -4,16 +4,28 @@ import com.github.javaparser.ast.comments.JavadocComment;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-public class CommentHelperMethods {
+/**
+ * CommentHelperMethods is a utility class with methods related to JavadocComment handling.
+ */
+public final class CommentHelperMethods {
 
   private CommentHelperMethods() {
     // Private constructor to prevent instantiation
   }
 
+  /**
+   * Returns the description of the given Javadoc comment, as text.
+   */
   public static String extractSummary(JavadocComment commentText) {
     return commentText.parse().getDescription().toText().strip();
   }
 
+  /**
+   * Extracts the contents of block tags like <code>@param</code> as strings. The resulting map has
+   * keys like "PARAM" (for <code>@param</code>) and "RETURN" (for <code>@return</code>) at the top
+   * level, and then the names and descriptions for each parameter. If there are no block tags, the
+   * resulting map is empty.
+   */
   public static Map<String, Map<String, String>> extractParamDescriptions(
       JavadocComment commentText) {
     Map<String, Map<String, String>> paramDescriptions = new LinkedHashMap<>();
@@ -29,8 +41,16 @@ public class CommentHelperMethods {
     return paramDescriptions;
   }
 
-  // Keeping this logic out of main analysisvisitor class.
-  public static void processCommentData(Map<String, Map<String, String>> commentData,
+  /**
+   * Separate the given comment into the shape expected by <code>CommentSummaryDescription</code>.
+   *
+   * @param commentData       a parameter description from <code>extractParamDescriptions</code>
+   * @param returns           if a return value is documented, it is appended here
+   * @param commentParams     if parameters are documented, this map is mutated to include them
+   * @param commentTypeParams if type parameters are documented, this map is mutated to add them
+   */
+  public static void processCommentData(
+      Map<String, Map<String, String>> commentData,
       StringBuilder returns,
       Map<String, String> commentParams,
       Map<String, String> commentTypeParams) {

--- a/ldj-maven-plugin-example/src/main/java/org/example/ExampleClass.java
+++ b/ldj-maven-plugin-example/src/main/java/org/example/ExampleClass.java
@@ -3,10 +3,12 @@ package org.example;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** ExampleClass prints a friendly greeting at INFO level. */
 public class ExampleClass implements ExampleInterface {
 
   private static final Logger logger = LoggerFactory.getLogger(ExampleClass.class);
 
+  /** Command-line entry point. */
   public static void main(String[] args) {
     logger.atInfo().log("Hello, world!");
   }

--- a/ldj-maven-plugin-example/src/main/java/org/example/ExampleInterface.java
+++ b/ldj-maven-plugin-example/src/main/java/org/example/ExampleInterface.java
@@ -1,5 +1,6 @@
 package org.example;
 
+/** ExampleInterface is a marker interface that exists to show the analyzer can parse interfaces. */
 public interface ExampleInterface {
 
 }

--- a/ldj-maven-plugin/src/main/java/com/infosupport/ldoc/mavenplugin/LivingDocumentationMojo.java
+++ b/ldj-maven-plugin/src/main/java/com/infosupport/ldoc/mavenplugin/LivingDocumentationMojo.java
@@ -17,6 +17,10 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 
+/**
+ * LivingDocumentationMojo is a Maven plugin that runs the LivingDocumentation Java analyzer on the
+ * project being built. The output is written to <code>target/livingdocumentation.json</code>.
+ */
 @Mojo(
     name = "livingdocumentation",
     requiresDependencyResolution = ResolutionScope.COMPILE,


### PR DESCRIPTION
This does not cover the classes in the `descriptions` package, and so does not remove the Checkstyle check.