### PR TITLE
Add TypeDescription.Builder for incremental construction of TypeDescriptions

### DIFF
--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/TypeDescription.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/TypeDescription.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public record TypeDescription(
@@ -50,8 +52,85 @@ public record TypeDescription(
 
     implements Description {
 
-  public TypeDescription(TypeType type, String fullName) {
-    this(type, fullName, List.of());
+  /** Builder class for constructing TypeDescriptions incrementally. */
+  public static class Builder {
+
+    private final TypeType type;
+    private int modifiers = Modifier.NONE.mask();
+    private final String fullName;
+    private final List<String> baseTypes = new ArrayList<>();
+    private Description comment = null;
+    private final List<Description> fields = new ArrayList<>();
+    private final List<Description> constructors = new ArrayList<>();
+    private final List<Description> methods = new ArrayList<>();
+    private final List<Description> attributes = new ArrayList<>();
+    private final List<Description> enumMembers = new ArrayList<>();
+
+    /** Start building a new TypeDescription with this TypeType and fully qualified name. */
+    public Builder(TypeType type, String fullName) {
+      this.type = type;
+      this.fullName = fullName;
+    }
+
+    /** Changes this Builder so that every product also has the given fully qualified base types. */
+    public Builder withBaseTypes(List<String> baseTypes) {
+      this.baseTypes.addAll(baseTypes);
+      return this;
+    }
+
+    /** Changes this Builder so that every product built also has the given modifiers. */
+    public Builder withModifiers(int modifiers) {
+      this.modifiers = this.modifiers | modifiers;
+      return this;
+    }
+
+    /** Changes this Builder so that the given comment is attached to every product. */
+    public Builder withComment(Description comment) {
+      this.comment = comment;
+      return this;
+    }
+
+    /** Changes this Builder so that the given attributes (annotations) are added to the product. */
+    public Builder withAttributes(List<Description> attributes) {
+      this.attributes.addAll(attributes);
+      return this;
+    }
+
+    /** Changes this Builder so the given members are added to the product. */
+    public Builder withMembers(Description... members) {
+      return withMembers(List.of(members));
+    }
+
+    /** Changes this Builder so the members in the given list are added to the product. */
+    public Builder withMembers(List<Description> members) {
+      for (Description member : members) {
+        if (member instanceof ConstructorDescription) {
+          this.constructors.add(member);
+        } else if (member instanceof MethodDescription) {
+          this.methods.add(member);
+        } else if (member instanceof FieldDescription) {
+          this.fields.add(member);
+        } else if (member instanceof EnumMemberDescription) {
+          this.enumMembers.add(member);
+        }
+      }
+      return this;
+    }
+
+    /** Produces an immutable product TypeDescription. */
+    public TypeDescription build() {
+      return new TypeDescription(
+          type,
+          modifiers,
+          fullName,
+          Collections.unmodifiableList(baseTypes),
+          comment,
+          Collections.unmodifiableList(fields),
+          Collections.unmodifiableList(constructors),
+          Collections.unmodifiableList(methods),
+          Collections.unmodifiableList(attributes),
+          Collections.unmodifiableList(enumMembers));
+    }
   }
 
   public TypeDescription(TypeType type, String fullName, List<String> baseTypes) {

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
@@ -61,10 +61,10 @@ class AnalysisVisitorTest {
   @Test
   void type_description_for_class() {
     assertIterableEquals(
-        List.of(new TypeDescription(TypeType.CLASS, "Foo")), parse("class Foo {}"));
+        List.of(new TypeDescription(TypeType.CLASS, "Foo", List.of())), parse("class Foo {}"));
 
     assertIterableEquals(
-        List.of(new TypeDescription(TypeType.CLASS, "some.example.Bar")),
+        List.of(new TypeDescription(TypeType.CLASS, "some.example.Bar", List.of())),
         parse("package some.example; class Bar {}"));
 
     assertIterableEquals(
@@ -79,10 +79,11 @@ class AnalysisVisitorTest {
   @Test
   void type_description_for_interface() {
     assertIterableEquals(
-        List.of(new TypeDescription(TypeType.INTERFACE, "Oogle")), parse("interface Oogle {}"));
+        List.of(new TypeDescription(TypeType.INTERFACE, "Oogle", List.of())),
+        parse("interface Oogle {}"));
 
     assertIterableEquals(
-        List.of(new TypeDescription(TypeType.INTERFACE, "some.example.Foogle")),
+        List.of(new TypeDescription(TypeType.INTERFACE, "some.example.Foogle", List.of())),
         parse("package some.example; interface Foogle {}"));
 
     assertIterableEquals(
@@ -108,21 +109,13 @@ class AnalysisVisitorTest {
   void constructor_description() {
     assertIterableEquals(
         List.of(
-            new TypeDescription(
-                TypeType.CLASS,
-                0,
-                "Bongo",
-                List.of(),
-                null,
-                List.of(),
-                List.of(
+            new TypeDescription.Builder(TypeType.CLASS, "Bongo")
+                .withMembers(
                     new ConstructorDescription(
                         new MemberDescription("Bongo"),
                         List.of(new ParameterDescription("java.lang.Object", "z", List.of())),
-                        List.of())),
-                List.of(),
-                List.of(),
-                List.of())),
+                        List.of()))
+                .build()),
         parse("class Bongo { Bongo(Object z) {} }"));
   }
 
@@ -130,15 +123,8 @@ class AnalysisVisitorTest {
   void method_description() {
     assertIterableEquals(
         List.of(
-            new TypeDescription(
-                TypeType.CLASS,
-                0,
-                "Zap",
-                List.of(),
-                null,
-                List.of(),
-                List.of(),
-                List.of(
+            new TypeDescription.Builder(TypeType.CLASS, "Zap")
+                .withMembers(
                     new MethodDescription(
                         new MemberDescription("does"),
                         "Zap",
@@ -146,9 +132,8 @@ class AnalysisVisitorTest {
                         List.of(
                             new ParameterDescription("java.lang.Object", "a", List.of()),
                             new ParameterDescription("java.lang.String", "b", List.of())),
-                        List.of())),
-                List.of(),
-                List.of())),
+                        List.of()))
+                .build()),
         parse("class Zap { Zap does(Object a, String b) {} }"));
   }
 
@@ -156,38 +141,25 @@ class AnalysisVisitorTest {
   void attribute_description() {
     assertIterableEquals(
         List.of(
-            new TypeDescription(
-                TypeType.CLASS,
-                0,
-                "Z",
-                List.of(),
-                null,
-                List.of(),
-                List.of(),
-                List.of(),
-                List.of(new AttributeDescription("java.lang.Deprecated", "Deprecated", List.of())),
-                List.of())),
+            new TypeDescription.Builder(TypeType.CLASS, "Z")
+                .withAttributes(
+                    List.of(
+                        new AttributeDescription("java.lang.Deprecated", "Deprecated", List.of())))
+                .build()),
         parse("@Deprecated class Z {}"));
 
     assertIterableEquals(
         List.of(
-            new TypeDescription(
-                TypeType.CLASS,
-                0,
-                "X",
-                List.of(),
-                null,
-                List.of(),
-                List.of(),
-                List.of(),
-                List.of(
-                    new AttributeDescription(
-                        "java.lang.SuppressWarnings",
-                        "SuppressWarnings",
-                        List.of(
-                            new AttributeArgumentDescription(
-                                "value", "java.lang.String", "\"unchecked\"")))),
-                List.of())),
+            new TypeDescription.Builder(TypeType.CLASS, "X")
+                .withAttributes(
+                    List.of(
+                        new AttributeDescription(
+                            "java.lang.SuppressWarnings",
+                            "SuppressWarnings",
+                            List.of(
+                                new AttributeArgumentDescription(
+                                    "value", "java.lang.String", "\"unchecked\"")))))
+                .build()),
         parse("@SuppressWarnings(\"unchecked\") class X {}"));
   }
 
@@ -303,15 +275,8 @@ class AnalysisVisitorTest {
   void comment_tests() {
     assertIterableEquals(
         List.of(
-            new TypeDescription(
-                TypeType.CLASS,
-                0,
-                "Example",
-                List.of(),
-                null,
-                List.of(),
-                List.of(),
-                List.of(
+            new TypeDescription.Builder(TypeType.CLASS, "Example")
+                .withMembers(
                     new MethodDescription(
                         new MemberDescription("does"),
                         "Example",
@@ -327,9 +292,8 @@ class AnalysisVisitorTest {
                         List.of(
                             new ParameterDescription("java.lang.Object", "a", List.of()),
                             new ParameterDescription("java.lang.String", "b", List.of())),
-                        List.of())),
-                List.of(),
-                List.of())),
+                        List.of()))
+                .build()),
         parse(
             """
                 class Example {
@@ -416,25 +380,20 @@ class AnalysisVisitorTest {
 
   @Test
   void enum_members() {
-    List<Description> parsed =
-        parse("""
-                enum Nationality {
-                  DUTCH,
-                  GERMAN;
-                }
-            """);
-
-    TypeDescription typeDescription = (TypeDescription) parsed.get(0);
-
-    List<EnumMemberDescription> expectedEnumMembers =
+    assertIterableEquals(
         List.of(
-            new EnumMemberDescription(
-                new MemberDescription("DUTCH", Modifier.PUBLIC.mask(), List.of()), List.of(), null),
-            new EnumMemberDescription(
-                new MemberDescription("GERMAN", Modifier.PUBLIC.mask(), List.of()), List.of(),
-                null));
-
-    assertEquals(expectedEnumMembers, typeDescription.enumMembers());
+            new TypeDescription.Builder(TypeType.ENUM, "Nationality")
+                .withMembers(
+                    new EnumMemberDescription(
+                        new MemberDescription("DUTCH", Modifier.PUBLIC.mask(), List.of()),
+                        List.of(),
+                        null),
+                    new EnumMemberDescription(
+                        new MemberDescription("GERMAN", Modifier.PUBLIC.mask(), List.of()),
+                        List.of(),
+                        null))
+                .build()),
+        parse("enum Nationality { DUTCH, GERMAN; }"));
   }
 
   @Test
@@ -457,26 +416,17 @@ class AnalysisVisitorTest {
     TypeDescription typeDescription = (TypeDescription) parsed.get(0);
 
     TypeDescription expected =
-        new TypeDescription(
-            TypeType.ENUM,
-            0,
-            "Nationality",
-            List.of(),
-            null,
-            List.of(
+        new TypeDescription.Builder(TypeType.ENUM, "Nationality")
+            .withMembers(
                 new FieldDescription(
                     new MemberDescription("counter", Modifier.NONE.mask(), List.of()),
                     "int",
                     null,
-                    null)),
-            List.of(
+                    null),
                 new ConstructorDescription(
                     new MemberDescription("Nationality"),
                     List.of(new ParameterDescription("int", "val", List.of())),
-                    List.of(new AssignmentDescription("this.counter", "=", "val")))),
-            List.of(),
-            List.of(),
-            List.of(
+                    List.of(new AssignmentDescription("this.counter", "=", "val"))),
                 new EnumMemberDescription(
                     new MemberDescription("DUTCH", Modifier.PUBLIC.mask(), List.of()),
                     List.of(new ArgumentDescription("int", "5")),
@@ -484,7 +434,8 @@ class AnalysisVisitorTest {
                 new EnumMemberDescription(
                     new MemberDescription("GERMAN", Modifier.PUBLIC.mask(), List.of()),
                     List.of(new ArgumentDescription("int", "10")),
-                    null)));
+                    null))
+            .build();
 
     assertEquals(expected, typeDescription);
   }

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/TypeDescriptionJsonTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/TypeDescriptionJsonTest.java
@@ -15,7 +15,7 @@ class TypeDescriptionJsonTest {
   void type_description_serializes_as_expected() throws IOException {
     assertEquals(
         mapper.readTree("{\"FullName\": \"com.example.Spam\"}"),
-        mapper.valueToTree(new TypeDescription(TypeType.CLASS, "com.example.Spam")));
+        mapper.valueToTree(new TypeDescription(TypeType.CLASS, "com.example.Spam", List.of())));
 
     assertEquals(
         mapper.readTree("{\"FullName\": \"foo.bar.Baz\", \"BaseTypes\": [\"snork\"]}"),
@@ -35,15 +35,9 @@ class TypeDescriptionJsonTest {
 
     assertEquals(
         mapper.readTree("{\"Modifiers\": 1026, \"FullName\": \"Wilma\"}"),
-        mapper.valueToTree(new TypeDescription(
-            TypeType.CLASS,
-            Modifier.PUBLIC.mask() | Modifier.SEALED.mask(),
-            "Wilma",
-            List.of(),
-            null,
-            List.of(),
-            List.of(),
-            List.of(),
-            List.of(), List.of())));
+        mapper.valueToTree(
+            new TypeDescription.Builder(TypeType.CLASS, "Wilma")
+                .withModifiers(Modifier.PUBLIC.mask() | Modifier.SEALED.mask())
+                .build()));
   }
 }


### PR DESCRIPTION
As discussed in #68. This doesn't actually save any LoC, because of the size of the `Builder` itself, but it does reduce code duplication a bit.