### PR TITLE
Add example app with Spring Events (not Messaging)

### DIFF
--- a/ldj-spring-event-example/README.md
+++ b/ldj-spring-event-example/README.md
@@ -1,0 +1,9 @@
+# Spring Event example
+
+This is an example application for LivingDocumentation Java that uses Spring application events.
+It exists to demonstrate the example Spring renderer.
+
+In the example, a fictional sandwich delivery service receives a single order for 6 sandwiches; in response, the app "updates the inventory", "dispatches sandwiches", and "generates" then "sends an invoice".
+None of this actually happens - instead, the different Spring beans just log what they would have done had they been implemented.
+
+There is no user interface.

--- a/ldj-spring-event-example/pom.xml
+++ b/ldj-spring-event-example/pom.xml
@@ -1,0 +1,44 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>ldj-spring-event-example</artifactId>
+
+  <parent>
+    <groupId>com.infosupport.livingdocumentation</groupId>
+    <artifactId>livingdocumentation-java</artifactId>
+    <version>1-SNAPSHOT</version>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <version>6.0.13</version>
+    </dependency>
+  </dependencies>
+
+  <properties>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.infosupport.livingdocumentation</groupId>
+        <artifactId>ldj-maven-plugin</artifactId>
+        <version>1-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>livingdocumentation</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/ldj-spring-event-example/src/main/java/org/example/EventApp.java
+++ b/ldj-spring-event-example/src/main/java/org/example/EventApp.java
@@ -1,0 +1,22 @@
+package org.example;
+
+import org.example.events.OrderPaid;
+import org.example.models.Order;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+/**
+ * An example application where we pretend 6 sandwiches were ordered by a hungry customer who lives
+ * at 123 Fake Street.
+ */
+public class EventApp {
+
+  /**
+   * Command-line entry point.
+   */
+  public static void main(String[] args) {
+    ApplicationContext context = new AnnotationConfigApplicationContext("org.example");
+
+    context.publishEvent(new OrderPaid(new Order(6, "123 Fake Street")));
+  }
+}

--- a/ldj-spring-event-example/src/main/java/org/example/events/InvoiceCreated.java
+++ b/ldj-spring-event-example/src/main/java/org/example/events/InvoiceCreated.java
@@ -1,0 +1,9 @@
+package org.example.events;
+
+/**
+ * InvoiceCreated occurs when an invoice for a sandwich order has been generated. A more realistic
+ * event would have fields representing the generated invoice.
+ */
+public final class InvoiceCreated {
+
+}

--- a/ldj-spring-event-example/src/main/java/org/example/events/InvoiceCreated.java
+++ b/ldj-spring-event-example/src/main/java/org/example/events/InvoiceCreated.java
@@ -6,4 +6,15 @@ package org.example.events;
  */
 public final class InvoiceCreated {
 
+  /**
+   * The number (hash code) of the order that this invoice is for.
+   */
+  public final long orderNumber;
+
+  /**
+   * Constructs (but does not yet publish) an InvoiceCreated event.
+   */
+  public InvoiceCreated(long orderNumber) {
+    this.orderNumber = orderNumber;
+  }
 }

--- a/ldj-spring-event-example/src/main/java/org/example/events/OrderPaid.java
+++ b/ldj-spring-event-example/src/main/java/org/example/events/OrderPaid.java
@@ -1,0 +1,21 @@
+package org.example.events;
+
+import org.example.models.Order;
+
+/**
+ * OrderPaid happening indicates that an order was paid in full.
+ */
+public final class OrderPaid {
+
+  /**
+   * The order that was paid.
+   */
+  public final Order order;
+
+  /**
+   * Constructs (but do not yet publish) an OrderPaid event.
+   */
+  public OrderPaid(Order order) {
+    this.order = order;
+  }
+}

--- a/ldj-spring-event-example/src/main/java/org/example/listeners/InventoryCounter.java
+++ b/ldj-spring-event-example/src/main/java/org/example/listeners/InventoryCounter.java
@@ -1,0 +1,26 @@
+package org.example.listeners;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.example.events.OrderPaid;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+
+/**
+ * InventoryCounter would keep track of how many sandwiches are ready to be sold, and perhaps cause
+ * the preparation of more sandwiches if the inventory drops below some level. This implementation
+ * does not do this, and only logs.
+ */
+@Service
+public final class InventoryCounter {
+
+  private final Log log = LogFactory.getLog(getClass());
+
+  /**
+   * Called when an order is paid, and the current inventory has to be updated to reflect this.
+   */
+  @EventListener
+  public void handleOrderPaid(OrderPaid event) {
+    log.info("Would now update inventory for order " + event.order);
+  }
+}

--- a/ldj-spring-event-example/src/main/java/org/example/listeners/InvoiceGenerator.java
+++ b/ldj-spring-event-example/src/main/java/org/example/listeners/InvoiceGenerator.java
@@ -1,0 +1,29 @@
+package org.example.listeners;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.example.events.InvoiceCreated;
+import org.example.events.OrderPaid;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+
+/**
+ * InvoiceGenerator would, given a fully paid order, generate an invoice (perhaps in PDF format) for
+ * the sandwich consumer to keep for their records, perhaps in case a warranty claim comes up. This
+ * implementation does not generate an invoice, but does emit an event that is has done so.
+ */
+@Service
+public final class InvoiceGenerator {
+
+  private final Log log = LogFactory.getLog(getClass());
+
+  /**
+   * Called when an order is fully paid up, which necessitates the generation of an invoice.
+   */
+  @EventListener
+  public InvoiceCreated handleOrderPaid(OrderPaid event) {
+    InvoiceCreated reaction = new InvoiceCreated();
+    log.info("Order %s paid, created invoice %s".formatted(event.order, reaction.hashCode()));
+    return reaction;
+  }
+}

--- a/ldj-spring-event-example/src/main/java/org/example/listeners/InvoiceGenerator.java
+++ b/ldj-spring-event-example/src/main/java/org/example/listeners/InvoiceGenerator.java
@@ -22,7 +22,7 @@ public final class InvoiceGenerator {
    */
   @EventListener
   public InvoiceCreated handleOrderPaid(OrderPaid event) {
-    InvoiceCreated reaction = new InvoiceCreated();
+    InvoiceCreated reaction = new InvoiceCreated(event.order.hashCode());
     log.info("Order %s paid, created invoice %s".formatted(event.order, reaction.hashCode()));
     return reaction;
   }

--- a/ldj-spring-event-example/src/main/java/org/example/listeners/InvoiceSender.java
+++ b/ldj-spring-event-example/src/main/java/org/example/listeners/InvoiceSender.java
@@ -1,0 +1,25 @@
+package org.example.listeners;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.example.events.InvoiceCreated;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+
+/**
+ * InvoiceSender would take a generated invoice and send it to the customer, perhaps using e-mail or
+ * postal mail. This implementation only logs.
+ */
+@Service
+public final class InvoiceSender {
+
+  private final Log log = LogFactory.getLog(getClass());
+
+  /**
+   * Called when an invoice is created and (thus) ready to be sent.
+   */
+  @EventListener
+  public void handleInvoiceCreated(InvoiceCreated event) {
+    log.info("Would now send invoice " + event.hashCode());
+  }
+}

--- a/ldj-spring-event-example/src/main/java/org/example/listeners/SandwichDispatcher.java
+++ b/ldj-spring-event-example/src/main/java/org/example/listeners/SandwichDispatcher.java
@@ -1,0 +1,25 @@
+package org.example.listeners;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.example.events.OrderPaid;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+
+/**
+ * SandwichDispatcher would, if it existed, send out a courier to deliver the requested number of
+ * sandwiches whenever an order is fully paid. The current implementation does not do this.
+ */
+@Service
+public final class SandwichDispatcher {
+
+  private final Log log = LogFactory.getLog(getClass());
+
+  /**
+   * Called when an order has been paid, and sandwiches need to be sent out to hungry customers.
+   */
+  @EventListener
+  public void handleOrderPaid(OrderPaid event) {
+    log.info("Would now dispatch order " + event.order);
+  }
+}

--- a/ldj-spring-event-example/src/main/java/org/example/models/Order.java
+++ b/ldj-spring-event-example/src/main/java/org/example/models/Order.java
@@ -1,0 +1,30 @@
+package org.example.models;
+
+/**
+ * A request for some quantity of sandwiches (which are assumed to be indistinguishable from each
+ * other) to be shipped to some address.
+ */
+public final class Order {
+  private final int quantity;
+
+  private final String address;
+
+  /**
+   * Constructs a new sandwich order.
+   */
+  public Order(int quantity, String address) {
+    if (quantity < 1) {
+      throw new IllegalArgumentException("Quantity must be strictly positive.");
+    }
+    this.quantity = quantity;
+    this.address = address;
+  }
+
+  /**
+   * Returns a human-readable string representation of this order.
+   */
+  @Override
+  public String toString() {
+    return "%d (%d sandwiches to %s)".formatted(hashCode(), quantity, address);
+  }
+}

--- a/ldj-spring-event-example/src/main/java/org/example/models/Order.java
+++ b/ldj-spring-event-example/src/main/java/org/example/models/Order.java
@@ -2,7 +2,7 @@ package org.example.models;
 
 /**
  * A request for some quantity of sandwiches (which are assumed to be indistinguishable from each
- * other) to be shipped to some address.
+ * other) to be shipped to some address. The object's hashCode stands in for an order number.
  */
 public final class Order {
   private final int quantity;

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
     <module>jacoco-report-aggregator</module>
     <module>ldj-maven-plugin</module>
     <module>ldj-maven-plugin-example</module>
+    <module>ldj-spring-event-example</module>
   </modules>
 
   <build>


### PR DESCRIPTION
This is a simple Spring app that uses [Application Events](https://docs.spring.io/spring-framework/reference/core/beans/context-introduction.html#context-functionality-events) to decouple fictional parts of a sandwich delivery service. When an order is paid, sandwiches are dispatched, inventory is updated, and an invoice is generated and then sent -- or at least, it would be, if this was not an example but a real app.

This is "just" Spring events, there is no messaging/networking/AMQP/brokers/etc involved.

A hypothetical Spring renderer could draw the following diagram based on this code:

![graf](https://github.com/Ali-chakaroun/ISEP-LivingDocumentation/assets/126832/ff1b4dda-73e4-4b74-8b52-701dfa0401ef)

This follows the conventions from the Pitstop example, [here](https://github.com/eNeRGy164/LivingDocumentation.Workshop/tree/main/2.living-documentation/solutions/25.PitstopDocumentationRenderer).