### PR TITLE
Add example app with Spring AMQP (not Events)

### DIFF
--- a/ldj-spring-amqp-example/README.md
+++ b/ldj-spring-amqp-example/README.md
@@ -1,0 +1,16 @@
+# Spring Boot AMQP example
+
+This is a Spring Boot application that serves as an example of a project using Spring AMQP that could be analyzed using the Living Documentation Java analyzer.
+
+A web interface collects an order for a sandwich, which is sent to the "kitchen".
+Once the sandwich is done, it is sent out for "delivery".
+Of course, neither of these things actually happen - instead, the relevant code just logs what it otherwise would have done.
+
+The example app requires a RabbitMQ message broker to be running.
+If Docker is available, the following command suffices:
+
+```shell
+docker run -p 5672:5672 --hostname rabbit rabbitmq
+```
+
+Once the app is successfully started, "orders" can be submitted on [http://localhost:8080](http://localhost:8080/).

--- a/ldj-spring-amqp-example/pom.xml
+++ b/ldj-spring-amqp-example/pom.xml
@@ -1,0 +1,54 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>ldj-spring-amqp-example</artifactId>
+
+  <parent>
+    <groupId>com.infosupport.livingdocumentation</groupId>
+    <artifactId>livingdocumentation-java</artifactId>
+    <version>1-SNAPSHOT</version>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>3.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-amqp</artifactId>
+      <version>3.1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-logging</artifactId>
+      <version>3.1.2</version>
+    </dependency>
+  </dependencies>
+
+  <properties>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.infosupport.livingdocumentation</groupId>
+        <artifactId>ldj-maven-plugin</artifactId>
+        <version>1-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>livingdocumentation</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/ldj-spring-amqp-example/src/main/java/org/example/DeliveryListener.java
+++ b/ldj-spring-amqp-example/src/main/java/org/example/DeliveryListener.java
@@ -7,14 +7,20 @@ import org.springframework.amqp.rabbit.annotation.RabbitHandler;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
 
+/**
+ * Delivery component. Listens on the 'delivery' queue for delivery instructions.
+ */
 @Component
 @RabbitListener(queues = "delivery")
 public class DeliveryListener {
 
   private final Logger logger = LoggerFactory.getLogger(DeliveryListener.class);
 
+  /**
+   * Called when a delivery instruction arrives.
+   */
   @RabbitHandler
   public void deliver(DeliveryInstruction delivery) {
-    logger.atInfo().log("Would now deliver a {}", delivery.order());
+    logger.atInfo().log("Would now deliver a {}", delivery.order);
   }
 }

--- a/ldj-spring-amqp-example/src/main/java/org/example/DeliveryListener.java
+++ b/ldj-spring-amqp-example/src/main/java/org/example/DeliveryListener.java
@@ -1,0 +1,20 @@
+package org.example;
+
+import org.example.domain.DeliveryInstruction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitHandler;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RabbitListener(queues = "delivery")
+public class DeliveryListener {
+
+  private final Logger logger = LoggerFactory.getLogger(DeliveryListener.class);
+
+  @RabbitHandler
+  public void deliver(DeliveryInstruction delivery) {
+    logger.atInfo().log("Would now deliver a {}", delivery.order());
+  }
+}

--- a/ldj-spring-amqp-example/src/main/java/org/example/ExampleAmqpApp.java
+++ b/ldj-spring-amqp-example/src/main/java/org/example/ExampleAmqpApp.java
@@ -6,20 +6,34 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 
+/**
+ * Example Spring Boot application that uses Spring AMQP to decouple different bits of a fictional
+ * sandwich delivery business. The web frontend, 'kitchen' and 'delivery' components run in the same
+ * process in this example, but communicate using a message broker.
+ */
 @SpringBootApplication
 @EnableRabbit
 public class ExampleAmqpApp {
 
+  /**
+   * Add the 'kitchen' queue to the context so that it is automatically declared if needed.
+   */
   @Bean
   public Queue kitchenQueue() {
     return new Queue("kitchen");
   }
 
+  /**
+   * Add the 'delivery' queue to the context so that it is automatically declared if needed.
+   */
   @Bean
   public Queue deliveryQueue() {
     return new Queue("delivery");
   }
 
+  /**
+   * Command-line entry point.
+   */
   public static void main(String[] args) {
     SpringApplication.run(ExampleAmqpApp.class, args);
   }

--- a/ldj-spring-amqp-example/src/main/java/org/example/ExampleAmqpApp.java
+++ b/ldj-spring-amqp-example/src/main/java/org/example/ExampleAmqpApp.java
@@ -1,0 +1,26 @@
+package org.example;
+
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.annotation.EnableRabbit;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootApplication
+@EnableRabbit
+public class ExampleAmqpApp {
+
+  @Bean
+  public Queue kitchenQueue() {
+    return new Queue("kitchen");
+  }
+
+  @Bean
+  public Queue deliveryQueue() {
+    return new Queue("delivery");
+  }
+
+  public static void main(String[] args) {
+    SpringApplication.run(ExampleAmqpApp.class, args);
+  }
+}

--- a/ldj-spring-amqp-example/src/main/java/org/example/KitchenListener.java
+++ b/ldj-spring-amqp-example/src/main/java/org/example/KitchenListener.java
@@ -1,0 +1,24 @@
+package org.example;
+
+import org.example.domain.DeliveryInstruction;
+import org.example.domain.SandwichOrder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitHandler;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Component;
+
+@Component
+@RabbitListener(queues = "kitchen")
+public class KitchenListener {
+
+  private final Logger logger = LoggerFactory.getLogger(KitchenListener.class);
+
+  @RabbitHandler
+  @SendTo("delivery")
+  public DeliveryInstruction prepare(SandwichOrder order) {
+    logger.atInfo().log("Would now prepare a {}", order);
+    return new DeliveryInstruction(order);
+  }
+}

--- a/ldj-spring-amqp-example/src/main/java/org/example/KitchenListener.java
+++ b/ldj-spring-amqp-example/src/main/java/org/example/KitchenListener.java
@@ -9,12 +9,19 @@ import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.stereotype.Component;
 
+/**
+ * Kitchen component. Listens on the 'kitchen' queue for new sandwiches to prepare. Once a sandwich
+ * is prepared, it is sent out for delivery on the 'delivery' queue.
+ */
 @Component
 @RabbitListener(queues = "kitchen")
 public class KitchenListener {
 
   private final Logger logger = LoggerFactory.getLogger(KitchenListener.class);
 
+  /**
+   * Called when a new sandwich order arrives.
+   */
   @RabbitHandler
   @SendTo("delivery")
   public DeliveryInstruction prepare(SandwichOrder order) {

--- a/ldj-spring-amqp-example/src/main/java/org/example/OrderController.java
+++ b/ldj-spring-amqp-example/src/main/java/org/example/OrderController.java
@@ -1,0 +1,24 @@
+package org.example;
+
+import org.example.domain.SandwichOrder;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class OrderController {
+
+  private final RabbitTemplate rabbitmq;
+
+  public OrderController(RabbitTemplate rabbitmq) {
+    this.rabbitmq = rabbitmq;
+  }
+
+  @PostMapping(value = "/order", produces = MediaType.TEXT_PLAIN_VALUE)
+  public String acceptOrder(@ModelAttribute SandwichOrder sandwichOrder) {
+    rabbitmq.convertAndSend("kitchen", sandwichOrder);
+    return "Thank you for your order! (Check the logs.)";
+  }
+}

--- a/ldj-spring-amqp-example/src/main/java/org/example/OrderController.java
+++ b/ldj-spring-amqp-example/src/main/java/org/example/OrderController.java
@@ -7,6 +7,9 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * OrderController takes POST requests from the web interface and sends them on to the kitchen.
+ */
 @RestController
 public class OrderController {
 

--- a/ldj-spring-amqp-example/src/main/java/org/example/domain/Bread.java
+++ b/ldj-spring-amqp-example/src/main/java/org/example/domain/Bread.java
@@ -1,0 +1,7 @@
+package org.example.domain;
+
+public enum Bread {
+  WHOLEWHEAT,
+  RYE,
+  ITALIAN
+}

--- a/ldj-spring-amqp-example/src/main/java/org/example/domain/Bread.java
+++ b/ldj-spring-amqp-example/src/main/java/org/example/domain/Bread.java
@@ -1,5 +1,8 @@
 package org.example.domain;
 
+/**
+ * Bread represents a choice of substrate to conveniently carry sandwich fillings (proteins).
+ */
 public enum Bread {
   WHOLEWHEAT,
   RYE,

--- a/ldj-spring-amqp-example/src/main/java/org/example/domain/DeliveryInstruction.java
+++ b/ldj-spring-amqp-example/src/main/java/org/example/domain/DeliveryInstruction.java
@@ -2,6 +2,20 @@ package org.example.domain;
 
 import java.io.Serializable;
 
-public record DeliveryInstruction(SandwichOrder order) implements Serializable {
+/**
+ * An instruction to deliver a prepared sandwich order somewhere.
+ */
+public final class DeliveryInstruction implements Serializable {
 
+  /**
+   * The order that has been prepared and is now ready for delivery.
+   */
+  public final SandwichOrder order;
+
+  /**
+   * Constructs a delivery instruction for the given order.
+   */
+  public DeliveryInstruction(SandwichOrder order) {
+    this.order = order;
+  }
 }

--- a/ldj-spring-amqp-example/src/main/java/org/example/domain/DeliveryInstruction.java
+++ b/ldj-spring-amqp-example/src/main/java/org/example/domain/DeliveryInstruction.java
@@ -1,0 +1,7 @@
+package org.example.domain;
+
+import java.io.Serializable;
+
+public record DeliveryInstruction(SandwichOrder order) implements Serializable {
+
+}

--- a/ldj-spring-amqp-example/src/main/java/org/example/domain/Protein.java
+++ b/ldj-spring-amqp-example/src/main/java/org/example/domain/Protein.java
@@ -1,5 +1,8 @@
 package org.example.domain;
 
+/**
+ * Protein represents some available choices for things to put into a sandwich.
+ */
 public enum Protein {
   CHICKEN,
   CHEESE,

--- a/ldj-spring-amqp-example/src/main/java/org/example/domain/Protein.java
+++ b/ldj-spring-amqp-example/src/main/java/org/example/domain/Protein.java
@@ -1,0 +1,8 @@
+package org.example.domain;
+
+public enum Protein {
+  CHICKEN,
+  CHEESE,
+  AVOCADO,
+  EGG
+}

--- a/ldj-spring-amqp-example/src/main/java/org/example/domain/SandwichOrder.java
+++ b/ldj-spring-amqp-example/src/main/java/org/example/domain/SandwichOrder.java
@@ -1,0 +1,7 @@
+package org.example.domain;
+
+import java.io.Serializable;
+
+public record SandwichOrder(Bread bread, Protein protein, String address) implements Serializable {
+
+}

--- a/ldj-spring-amqp-example/src/main/java/org/example/domain/SandwichOrder.java
+++ b/ldj-spring-amqp-example/src/main/java/org/example/domain/SandwichOrder.java
@@ -2,6 +2,29 @@ package org.example.domain;
 
 import java.io.Serializable;
 
-public record SandwichOrder(Bread bread, Protein protein, String address) implements Serializable {
+/**
+ * SandwichOrder represents both a sandwich and a destination address for that sandwich.
+ */
+public final class SandwichOrder implements Serializable {
 
+  private final Bread bread;
+  private final Protein protein;
+  private final String address;
+
+  /**
+   * Constructs (but does not yet transmit) a sandwich order.
+   */
+  public SandwichOrder(Bread bread, Protein protein, String address) {
+    this.bread = bread;
+    this.protein = protein;
+    this.address = address;
+  }
+
+  /**
+   * Returns a programmer-readable representation of this order.
+   */
+  @Override
+  public String toString() {
+    return "SandwichOrder{" + bread + ", " + protein + ", '" + address + '\'' + '}';
+  }
 }

--- a/ldj-spring-amqp-example/src/main/resources/static/index.html
+++ b/ldj-spring-amqp-example/src/main/resources/static/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <style>
+    body {
+      max-width: 500px;
+      margin: 3em auto;
+      line-height: 1.6em;
+    }
+  </style>
+  <title>Ye Olde Sandwich Shoppe</title>
+</head>
+<body>
+<h1>Ye Olde Sandwich Shoppe</h1>
+<form action="/order" method="post">
+  <div>
+    <label>
+      Address
+      <input type="text" name="address" value="Avenida da Pastelaria 1903, Lisbon">
+    </label>
+  </div>
+
+  <div>
+    <label>
+      Bread
+      <select name="bread">
+        <option value="WHOLEWHEAT">Whole wheat</option>
+        <option value="RYE">Rye</option>
+        <option value="ITALIAN">Italian</option>
+      </select>
+    </label>
+  </div>
+
+  <div>
+    <label>
+      Protein
+      <select name="protein">
+        <option value="CHICKEN">Chicken</option>
+        <option value="CHEESE">Cheese</option>
+        <option value="AVOCADO">Avocado</option>
+        <option value="EGG">Egg</option>
+      </select>
+    </label>
+  </div>
+
+  <input type="submit">
+</form>
+</body>
+</html>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
     <module>jacoco-report-aggregator</module>
     <module>ldj-maven-plugin</module>
     <module>ldj-maven-plugin-example</module>
+    <module>ldj-spring-amqp-example</module>
   </modules>
 
   <build>


### PR DESCRIPTION
This is similar to #86, but unlike that PR, the decoupled components in this app communicate through an AMQP message broker (RabbitMQ). The different components could theoretically live on different machines, even if they do not currently.

Also unlike that app, this app has a web interface: in addition to the Spring Boot AMQP starter, it pulls in the Spring Boot web starter so it can use Tomcat to show a simple interface on port 8080.

A diagram generated from this code would look similar to the one in #86, but a bit simpler: `OrderController` sends a `SandwichOrder` to `KitchenListener`, then `KitchenListener` sends a `DeliveryInstruction` wrapping that order to `DeliveryListener`.