### PR TITLE
Make ReturnDescription in void method have empty-string Expression

### DIFF
--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
@@ -288,7 +288,7 @@ public class AnalysisVisitor extends GenericListVisitorAdapter<Description, Anal
   /** Describes a <code>return</code> statement, including the returned expression if present. */
   @Override
   public List<Description> visit(ReturnStmt n, Analyzer arg) {
-    return List.of(new ReturnDescription(n.getExpression().map(Node::toString).orElse(null)));
+    return List.of(new ReturnDescription(n.getExpression().map(Node::toString).orElse("")));
   }
 
   /** Describes an <code>if</code> statement or tree of <code>if</code> statements. */

--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/ReturnDescription.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/descriptions/ReturnDescription.java
@@ -1,18 +1,11 @@
 package com.infosupport.ldoc.analyzerj.descriptions;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record ReturnDescription(
     @JsonProperty("Expression")
-    @JsonInclude(Include.NON_NULL)
     String expression
 ) implements Description {
-
-  public ReturnDescription() {
-    this(null);
-  }
 
   @JsonProperty(value = "$type", index = -2)
   public String type() {

--- a/analyzer-java/src/main/resources/jsonschema/schema.json
+++ b/analyzer-java/src/main/resources/jsonschema/schema.json
@@ -209,7 +209,9 @@
         }
       },
       "additionalProperties": false,
-      "required": []
+      "required": [
+        "Expression"
+      ]
     },
     "fields": {
       "type": "array",

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
@@ -164,7 +164,7 @@ class AnalysisVisitorTest {
 
   @Test
   void return_statement() {
-    assertIterableEquals(List.of(new ReturnDescription()), parseFragment("return;"));
+    assertIterableEquals(List.of(new ReturnDescription("")), parseFragment("return;"));
 
     assertIterableEquals(List.of(new ReturnDescription("1 + 2")), parseFragment("return 1 + 2;"));
   }

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/ForEachDescriptionJsonTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/ForEachDescriptionJsonTest.java
@@ -19,7 +19,8 @@ class ForEachDescriptionJsonTest {
           "Expression": "String piece : pieces",
           "Statements": [
             {
-              "$type": "LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions"
+              "$type": "LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions",
+              "Expression": ""
             }
           ]
         }
@@ -28,6 +29,6 @@ class ForEachDescriptionJsonTest {
     assertEquals(
         mapper.readTree(expected),
         mapper.valueToTree(
-            new ForEachDescription("String piece : pieces", List.of(new ReturnDescription()))));
+            new ForEachDescription("String piece : pieces", List.of(new ReturnDescription("")))));
   }
 }

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/ReturnDescriptionJsonTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/ReturnDescriptionJsonTest.java
@@ -14,7 +14,8 @@ class ReturnDescriptionJsonTest {
   void return_description_serializes_as_expected() throws IOException {
     String plain = """
         {
-          "$type": "LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions"
+          "$type": "LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions",
+          "Expression": ""
         }
         """;
     String value = """
@@ -24,7 +25,7 @@ class ReturnDescriptionJsonTest {
         }
         """;
 
-    assertEquals(mapper.readTree(plain), mapper.valueToTree(new ReturnDescription()));
+    assertEquals(mapper.readTree(plain), mapper.valueToTree(new ReturnDescription("")));
     assertEquals(mapper.readTree(value), mapper.valueToTree(new ReturnDescription("1")));
   }
 }

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/SwitchDescriptionJsonTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/SwitchDescriptionJsonTest.java
@@ -20,24 +20,20 @@ class SwitchDescriptionJsonTest {
           "Sections": [
             {
               "Labels": ["Spring"],
-              "Statements": [
-                {
-                  "$type": "LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions",
-                  "Expression": ""
-                }
-              ]
+              "Statements": [{
+                "$type": "LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions",
+                "Expression": ""
+              }]
             },
             {
               "Labels": ["Summer"]
             },
             {
               "Labels": ["default"],
-              "Statements": [
-                {
-                  "$type": "LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions",
-                  "Expression": ""
-                }
-              ]
+              "Statements": [{
+                "$type": "LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions",
+                "Expression": ""
+              }]
             }
           ]
         }

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/SwitchDescriptionJsonTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/descriptions/SwitchDescriptionJsonTest.java
@@ -22,7 +22,8 @@ class SwitchDescriptionJsonTest {
               "Labels": ["Spring"],
               "Statements": [
                 {
-                  "$type": "LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions"
+                  "$type": "LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions",
+                  "Expression": ""
                 }
               ]
             },
@@ -33,7 +34,8 @@ class SwitchDescriptionJsonTest {
               "Labels": ["default"],
               "Statements": [
                 {
-                  "$type": "LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions"
+                  "$type": "LivingDocumentation.ReturnDescription, LivingDocumentation.Descriptions",
+                  "Expression": ""
                 }
               ]
             }
@@ -44,8 +46,8 @@ class SwitchDescriptionJsonTest {
     assertEquals(
         mapper.readTree(expected),
         mapper.valueToTree(new SwitchDescription("season", List.of(
-            new SwitchSection(List.of("Spring"), List.of(new ReturnDescription())),
+            new SwitchSection(List.of("Spring"), List.of(new ReturnDescription(""))),
             new SwitchSection(List.of("Summer"), List.of()),
-            new SwitchSection(List.of("default"), List.of(new ReturnDescription()))))));
+            new SwitchSection(List.of("default"), List.of(new ReturnDescription("")))))));
   }
 }

--- a/docs/JSONDocumentation.md
+++ b/docs/JSONDocumentation.md
@@ -359,10 +359,10 @@ Each statement is one of the following options. The statement type is distinguis
 
 #### Required keys:
 
-| Key        | Type   | .NET                                     | Java                                                                             |
-|------------|--------|------------------------------------------|----------------------------------------------------------------------------------|
-| $type      | const  | Type of the statement                    | Type of the statement                                                            |
-| Expression | string | Return expression, null for empty return | Return expression, this is not a required key. Key is left out for empty return. |
+| Key        | Type   | .NET                              | Java                              |
+|------------|--------|-----------------------------------|-----------------------------------|
+| $type      | const  | Type of the statement             | Type of the statement             |
+| Expression | string | Return expression or empty string | Return expression or empty string |
 
 
 ## Argument


### PR DESCRIPTION
This follows more closely what the C# implementation does for this case; the idea is to make the behavior the same as upstream.

The JSON documentation and JSON Schema are updated to match.

Fixes #111.