### PR TITLE
Add initial Gradle plugin

### DIFF
--- a/ldj-gradle-plugin/README.md
+++ b/ldj-gradle-plugin/README.md
@@ -1,0 +1,42 @@
+# Living Documentation Gradle plugin
+
+This plugin adds Living Documentation support to Gradle Java projects.
+
+It automatically generates a `livingdocumentation.json` file for the Java source that's in the project every time the project is compiled.
+In addition, the task can be run manually with `./gradlew generateLivingDocumentation` (or `./gradlew gLD` for short), or through IDE integration.
+
+The JSON file follows the [JSON documentation](../docs/JSONDocumentation.md) and [JSON Schema](../analyzer-java/src/main/resources/jsonschema/schema.json).
+For more information about writing renderers that consume that file, see the [top-level README](../README.md).
+
+## Building the plugin
+
+Use Maven to build the plugin:
+
+```
+mvn package
+```
+
+The Gradle plugin JAR is now in `target/ldj-gradle-plugin-1-SNAPSHOT.jar`.
+
+## Using the plugin
+
+Add the plugin to your build script's classpath, for example by adding the following to the top of your `build.gradle` file:
+
+```
+buildscript {
+    repositories {
+        flatDir { dir '/path/to/ISEP-LivingDocumentation/ldj-gradle-plugin/target' }
+    }
+    dependencies {
+        classpath 'com.infosupport.livingdocumentation:ldj-gradle-plugin:1-SNAPSHOT'
+    }
+}
+```
+
+Then, apply the plugin:
+
+```
+apply plugin: 'com.infosupport.ldoc'
+```
+
+The plugin assumes that the `java` plugin is also applied to the project.

--- a/ldj-gradle-plugin/pom.xml
+++ b/ldj-gradle-plugin/pom.xml
@@ -1,0 +1,72 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>ldj-gradle-plugin</artifactId>
+
+  <parent>
+    <groupId>com.infosupport.livingdocumentation</groupId>
+    <artifactId>livingdocumentation-java</artifactId>
+    <version>1-SNAPSHOT</version>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.infosupport.livingdocumentation</groupId>
+      <artifactId>analyzer-java</artifactId>
+      <version>1-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+       <groupId>dev.gradleplugins</groupId>
+       <artifactId>gradle-api</artifactId>
+       <version>8.4</version>
+       <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <properties>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.0</version>
+        <configuration>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>**/module-info.class</exclude>
+              </excludes>
+            </filter>
+          </filters>
+          <transformers>
+            <transformer
+              implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+              <resource>MANIFEST.MF</resource>
+            </transformer>
+            <transformer
+              implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+            <transformer
+              implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
+          </transformers>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/ldj-gradle-plugin/src/main/java/com/infosupport/ldoc/gradleplugin/LivingDocumentationPlugin.java
+++ b/ldj-gradle-plugin/src/main/java/com/infosupport/ldoc/gradleplugin/LivingDocumentationPlugin.java
@@ -1,0 +1,34 @@
+package com.infosupport.ldoc.gradleplugin;
+
+import org.gradle.api.NonNullApi;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.tasks.SourceSet;
+
+/**
+ * LivingDocumentationPlugin adds Living Documentation JSON generation tasks to the first source
+ * directory of every Java source set in the project.
+ */
+@NonNullApi
+public class LivingDocumentationPlugin implements Plugin<Project> {
+
+  private static final String OUTPUT_FILENAME = "livingdocumentation.json";
+
+  @Override
+  public void apply(Project project) {
+    project.getExtensions().getByType(JavaPluginExtension.class).getSourceSets().all(set -> {
+      if (SourceSet.isMain(set)) {
+        String name = set.getTaskName("generate", "LivingDocumentation");
+
+        project.getTasks().register(name, LivingDocumentationTask.class, task -> {
+          task.getCompileClasspath().setFrom(set.getCompileClasspath());
+          task.getInputDirectory().set(set.getJava().getSourceDirectories().iterator().next());
+          task.getOutputFile().set(project.getLayout().getBuildDirectory().file(OUTPUT_FILENAME));
+        });
+
+        project.getTasks().named(set.getClassesTaskName()).configure(task -> task.dependsOn(name));
+      }
+    });
+  }
+}

--- a/ldj-gradle-plugin/src/main/java/com/infosupport/ldoc/gradleplugin/LivingDocumentationTask.java
+++ b/ldj-gradle-plugin/src/main/java/com/infosupport/ldoc/gradleplugin/LivingDocumentationTask.java
@@ -1,0 +1,45 @@
+package com.infosupport.ldoc.gradleplugin;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.infosupport.ldoc.analyzerj.AnalysisJob;
+import com.infosupport.ldoc.analyzerj.Analyzer;
+import java.io.File;
+import java.io.IOException;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.CompileClasspath;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+
+/**
+ * LivingDocumentationTask runs the Java analyzer on the input source directory (if it has changed).
+ */
+public abstract class LivingDocumentationTask extends DefaultTask {
+
+  @InputDirectory
+  public abstract DirectoryProperty getInputDirectory();
+
+  @InputFiles
+  @CompileClasspath
+  public abstract ConfigurableFileCollection getCompileClasspath();
+
+  @OutputFile
+  public abstract RegularFileProperty getOutputFile();
+
+  /**
+   * Analyzes the input directory.
+   */
+  @TaskAction
+  public void perform() throws IOException {
+    AnalysisJob job = new AnalysisJob(
+        getInputDirectory().getAsFile().get().toPath(),
+        getOutputFile().getAsFile().get().toPath(),
+        getCompileClasspath().getFiles().stream().map(File::getPath).toList(),
+        false);
+    new Analyzer(new ObjectMapper()).analyze(job);
+  }
+}

--- a/ldj-gradle-plugin/src/main/resources/META-INF/gradle-plugins/com.infosupport.ldoc.properties
+++ b/ldj-gradle-plugin/src/main/resources/META-INF/gradle-plugins/com.infosupport.ldoc.properties
@@ -1,0 +1,1 @@
+implementation-class=com.infosupport.ldoc.gradleplugin.LivingDocumentationPlugin

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
     <module>jacoco-report-aggregator</module>
     <module>ldj-maven-plugin</module>
     <module>ldj-maven-plugin-example</module>
+    <module>ldj-gradle-plugin</module>
     <module>ldj-spring-amqp-example</module>
     <module>ldj-spring-event-example</module>
     <module>ldj-spring-renderer-example</module>


### PR DESCRIPTION
The Gradle plugin follows the behavior of the Maven plugin: if it is applied, it automatically generates a `livingdocumentation.json` file for the Java source that's in the project every time the project is compiled. In addition, the task can be run manually with `./gradlew generateLivingDocumentation` (or `./gradlew gLD` for short), or through IDE integration. Since Gradle tracks input and output files, this is a no-op if no files have changed since the last time the JSON was generated.

Since the plugin is (of course) not yet published, it needs to be built and added to the build script classpath manually. To try it out in a new Gradle project, add this to the top, changing the path to match:

```groovy
buildscript {
    repositories {
        flatDir { dir '/path/to/ISEP-LivingDocumentation/ldj-gradle-plugin/target' }
    }
    dependencies {
        classpath 'com.infosupport.livingdocumentation:ldj-gradle-plugin:1-SNAPSHOT'
    }
}
```

Then, add to the bottom:

```groovy
apply plugin: 'com.infosupport.ldoc'
```

The plugin assumes that the 'java' plugin is also applied to the project.

Closes #44.