### PR TITLE
Don't assume comments on types are always Javadoc

### DIFF
--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
@@ -104,11 +104,11 @@ public class AnalysisVisitor extends GenericListVisitorAdapter<Description, Anal
     return List.of(new AttributeDescription(type.getQualifiedName(), n.getNameAsString(), args));
   }
 
-
   private TypeDescription.Builder typeBuilder(TypeType typeType,
       TypeDeclaration<? extends TypeDeclaration<?>> n, Analyzer arg) {
     String name = n.getFullyQualifiedName().orElseThrow();
-    Description comment = n.getComment().map(z -> z.accept(this, arg).get(0))
+    Description comment = n.getComment()
+        .flatMap(z -> z.accept(this, arg).stream().findFirst())
         .orElse(null);
     return new TypeDescription.Builder(typeType, name)
         .withModifiers(combine(n.getModifiers()))

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
@@ -285,6 +285,15 @@ class AnalysisVisitorTest {
   @Test
   void comment_tests() {
     assertIterableEquals(
+        List.of(new TypeDescription.Builder(TypeType.ENUM, "TestEnum").build()),
+        parse("/* Non-java-doc comment */ enum TestEnum { }"));
+
+    assertIterableEquals(
+        List.of(new TypeDescription.Builder(TypeType.CLASS, "TestClass")
+            .withMembers(new FieldDescription(new MemberDescription("foo"), "int", null)).build()),
+        parse("class TestClass { /* Not Javadoc */ int foo; }"));
+
+    assertIterableEquals(
         List.of(
             new TypeDescription.Builder(TypeType.CLASS, "Example")
                 .withMembers(


### PR DESCRIPTION
This uses the same approach as comments on members, that is, it still visits the comment but doesn't depend on that producing a Description.

Also adds test.

Fixes #134.