### PR TITLE
Ignore Javadoc comments on top-level compilation units

### DIFF
--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
@@ -1,5 +1,6 @@
 package com.infosupport.ldoc.analyzerj;
 
+import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.AnnotationDeclaration;
@@ -117,6 +118,14 @@ public class AnalysisVisitor extends GenericListVisitorAdapter<Description, Anal
         .withAttributes(visit(n.getAnnotations(), arg));
   }
 
+  /** Describe a top-level compilation unit. */
+  @Override
+  public List<Description> visit(CompilationUnit n, Analyzer arg) {
+    // We do not care about top-level comments, e.g. those in package-info.java. Remove them.
+    n.removeComment();
+    // Other than that, the default behavior is fine.
+    return super.visit(n, arg);
+  }
 
   /** Describes a class or interface (Java) as a Type with TypeType CLASS or INTERFACE. */
   @Override

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
@@ -333,6 +333,14 @@ class AnalysisVisitorTest {
   }
 
   @Test
+  void package_level_comment() {
+    // Ignore package-level Javadoc comments, since there is no place for them in the JSON schema.
+    assertIterableEquals(
+        List.of(),
+        parse("/** Package javadoc. */ package Playground;"));
+  }
+
+  @Test
   void class_and_method_modifiers() {
     List<Description> parsed =
         parse(


### PR DESCRIPTION
There is not really a place for these in the JSON schema; best to just ignore them.

Fixes #145.