### PR TITLE
Fix annotation with variable declaration

### DIFF
--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
@@ -434,12 +434,13 @@ public class AnalysisVisitor extends GenericListVisitorAdapter<Description, Anal
             !commentTypeParams.isEmpty() ? commentTypeParams : null));
   }
 
-  /** Describes a Variable Declaration Expression. As these are not supported in the JSON, there is
+  /**
+   * Describes a Variable Declaration Expression. As these are not supported in the JSON, there is
    * no matching description. This method is explicitly implemented to return null in order to
    * prevent annotations being visited that are attached to the Variable Declaration.
    */
   @Override
   public List<Description> visit(VariableDeclarationExpr n, Analyzer arg) {
-    return null;
+    return List.of();
   }
 }

--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
@@ -24,6 +24,7 @@ import com.github.javaparser.ast.expr.MemberValuePair;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NormalAnnotationExpr;
 import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
+import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.stmt.CatchClause;
 import com.github.javaparser.ast.stmt.ForEachStmt;
 import com.github.javaparser.ast.stmt.IfStmt;
@@ -431,5 +432,14 @@ public class AnalysisVisitor extends GenericListVisitorAdapter<Description, Anal
             summary,
             !commentParams.isEmpty() ? commentParams : null,
             !commentTypeParams.isEmpty() ? commentTypeParams : null));
+  }
+
+  /** Describes a Variable Declaration Expression. As these are not supported in the JSON, there is
+   * no matching description. This method is explicitly implemented to return null in order to
+   * prevent annotations being visited that are attached to the Variable Declaration.
+   */
+  @Override
+  public List<Description> visit(VariableDeclarationExpr n, Analyzer arg) {
+    return null;
   }
 }

--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
@@ -436,8 +436,8 @@ public class AnalysisVisitor extends GenericListVisitorAdapter<Description, Anal
 
   /**
    * Describes a Variable Declaration Expression. As these are not supported in the JSON, there is
-   * no matching description. This method is explicitly implemented to return null in order to
-   * prevent annotations being visited that are attached to the Variable Declaration.
+   * no matching description. This method is explicitly implemented to return an empty list in order
+   * to prevent annotations being visited that are attached to the Variable Declaration.
    */
   @Override
   public List<Description> visit(VariableDeclarationExpr n, Analyzer arg) {

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
@@ -554,6 +554,29 @@ class AnalysisVisitorTest {
 
     assertEquals(expected, typeDescription);
   }
+
+
+  @Test
+  void variable_declaration_with_annotation() {
+    String code = """
+        class Test {
+        void main(String[] args) {
+            @SuppressWarnings
+            int x = 0;
+          }
+          }
+        """;
+
+    List<Description> expected = List.of(new TypeDescription.Builder(TypeType.CLASS, "Test")
+            .withMembers(new MethodDescription(
+                new MemberDescription("main", 0, List.of(), null),
+                null, List.of(new ParameterDescription("java.lang.String[]", "args", List.of())),
+                List.of()
+            ))
+        .build());
+
+    assertIterableEquals(parse(code), expected);
+  }
 }
 
 

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
@@ -559,23 +559,14 @@ class AnalysisVisitorTest {
   @Test
   void variable_declaration_with_annotation() {
     String code = """
-        class Test {
-        void main(String[] args) {
-            @SuppressWarnings
+        @SuppressWarnings
             int x = 0;
-          }
-          }
+            return x;
         """;
 
-    List<Description> expected = List.of(new TypeDescription.Builder(TypeType.CLASS, "Test")
-            .withMembers(new MethodDescription(
-                new MemberDescription("main", 0, List.of(), null),
-                null, List.of(new ParameterDescription("java.lang.String[]", "args", List.of())),
-                List.of()
-            ))
-        .build());
+    List<Description> expected = List.of(new ReturnDescription("x"));
 
-    assertIterableEquals(parse(code), expected);
+    assertIterableEquals(parseFragment(code), expected);
   }
 }
 


### PR DESCRIPTION
Simply return null on a variable declaration so that the attached Annotation is not visited and thus not included as a statement.

Fixes #147 