### PR TITLE
Also ignore Javadoc, annotations on package declarations

### DIFF
--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
@@ -3,6 +3,7 @@ package com.infosupport.ldoc.analyzerj;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.body.AnnotationDeclaration;
 import com.github.javaparser.ast.body.AnnotationMemberDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
@@ -159,6 +160,12 @@ public class AnalysisVisitor extends GenericListVisitorAdapter<Description, Anal
     n.removeComment();
     // Other than that, the default behavior is fine.
     return super.visit(n, arg);
+  }
+
+  /** Describe a package declaration, by skipping it. It is not represented in the JSON. */
+  @Override
+  public List<Description> visit(PackageDeclaration n, Analyzer arg) {
+    return List.of();
   }
 
   /** Describes a class or interface (Java) as a Type with TypeType CLASS or INTERFACE. */

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
@@ -295,6 +295,18 @@ class AnalysisVisitorTest {
         parse("class TestClass { /* Not Javadoc */ int foo; }"));
 
     assertIterableEquals(
+        List.of(new TypeDescription.Builder(TypeType.INTERFACE, "TestInterface")
+            .withComment(new DocumentationCommentsDescription("Bar.", null, "Foo.", null, null))
+            .build()),
+        parse("/** Foo. Bar. */ interface TestInterface {}"));
+
+    assertIterableEquals(
+        List.of(new TypeDescription.Builder(TypeType.STRUCT, "org.example.TestRecord")
+            .withComment(new DocumentationCommentsDescription(null, null, "Present.", null, null))
+            .build()),
+        parse("/** Ignored. */ package org.example; /** Present. */ record TestRecord() {}"));
+
+    assertIterableEquals(
         List.of(
             new TypeDescription.Builder(TypeType.CLASS, "Example")
                 .withMembers(
@@ -339,6 +351,11 @@ class AnalysisVisitorTest {
     assertIterableEquals(
         List.of(),
         parse("/** Package javadoc. */ package Playground;"));
+
+    // Multiple top-level Javadoc comments should still be ignored.
+    assertIterableEquals(
+        List.of(),
+        parse("/** First javadoc. */ /** Second javadoc. */ package Playground;"));
   }
 
   @Test


### PR DESCRIPTION
There is not really a place for these in the JSON schema either; best to just ignore them.

Fixes #145.