### PR TITLE
Assume method calls without scope are calls to 'this'

### DIFF
--- a/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
+++ b/analyzer-java/src/main/java/com/infosupport/ldoc/analyzerj/AnalysisVisitor.java
@@ -65,6 +65,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * AnalysisVisitor converts a JavaParser parse tree into a list of {@link Description} objects. The
@@ -151,6 +152,19 @@ public class AnalysisVisitor extends GenericListVisitorAdapter<Description, Anal
         .withComment(comment)
         .withMembers(visit(n.getMembers(), arg))
         .withAttributes(visit(n.getAnnotations(), arg));
+  }
+
+  /** Return the fully qualified name of the nearest enclosing type (class, interface, ...) of e. */
+  private Optional<String> findEnclosingType(Node e) {
+    while (e != null) {
+      if (e instanceof TypeDeclaration<?> td) {
+        return td.getFullyQualifiedName();
+      }
+
+      e = e.getParentNode().orElse(null);
+    }
+
+    return Optional.empty();
   }
 
   /** Describe a top-level compilation unit. */
@@ -440,7 +454,7 @@ public class AnalysisVisitor extends GenericListVisitorAdapter<Description, Anal
     }
     return List.of(
         new InvocationDescription(
-            n.getScope().map(this::resolve).orElse("?"),
+            n.getScope().map(this::resolve).or(() -> findEnclosingType(n)).orElse("?"),
             n.getNameAsString(),
             arguments));
   }

--- a/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
+++ b/analyzer-java/src/test/java/com/infosupport/ldoc/analyzerj/AnalysisVisitorTest.java
@@ -51,7 +51,7 @@ class AnalysisVisitorTest {
   }
 
   private List<Description> parseFragment(String fragment) {
-    String source = String.format("class Test { int test() { %s } }", fragment);
+    String source = String.format("package unit; class Test { int test() { %s } }", fragment);
     List<Description> unit = parse(source);
     List<Description> methods = ((TypeDescription) unit.get(0)).methods();
     List<Description> statements = ((MethodDescription) methods.get(0)).statements();
@@ -273,6 +273,14 @@ class AnalysisVisitorTest {
                 "println",
                 List.of(new ArgumentDescription("java.lang.String", "\"Hello!\"")))),
         parseFragment("System.out.println(\"Hello!\");"));
+
+    assertIterableEquals(
+        List.of(new InvocationDescription("unit.Test", "hashCode", List.of())),
+        parseFragment("this.hashCode();"));
+
+    assertIterableEquals(
+        List.of(new InvocationDescription("unit.Test", "hashCode", List.of())),
+        parseFragment("hashCode();"));
   }
 
   @Test


### PR DESCRIPTION
For example, if we are in a class Customer, then the following call:

    setName("Bobby");

should get `org.example.Customer` as its `ContainingType`, not `?`.

Also adds tests.